### PR TITLE
chore: update apko shas for v0.0.0

### DIFF
--- a/apko/private/versions.bzl
+++ b/apko/private/versions.bzl
@@ -3,11 +3,11 @@
 # Add new versions by running
 # ./scripts/mirror_apko.sh
 APKO_VERSIONS = {
-    "v0.0.0": {
-        "darwin_amd64": "sha256-z/wJ7ZAFRoEIOCNvCLd4XnKAb8R4jvG8P7d835ZvckQ=",
-        "darwin_arm64": "sha256-kCZoMpop4VVPiFVJJVVheL1aWWmBO11u3LiULmcT93o=",
-        "linux_386": "sha256-Uk7+nsjviVFFSLOHue8Us1mTnBvTFoEj8QVtFUriypI=",
-        "linux_amd64": "sha256-5HYEVTVbWO+Mkjse9Fphkm2EmwT5lraf3BCTFku7Wvg=",
-        "linux_arm64": "sha256-bjdZPrwmNOtqM/4BIMHae6qPnXXUiywftbYeVxeHWpk=",
+    "v0.0.0": { 
+        "darwin_amd64": "sha256-hZ253iuIVqEOTQ4rrX1DrgOMqnxaHM6b8iUeUjd1ZBY=",
+        "darwin_arm64": "sha256-OX8S8TjiVenvc71CMWRqZM/JKOItTeKxLYk48HTY8m0=",
+        "linux_386": "sha256-sw4xdL7SN67wYz59J5XgEgtx8wdF4tS2SA1FQt/9J48=",
+        "linux_amd64": "sha256-Zc4OUCWYfuIe81S0UeCwPOA75Xb7uof9Nm5P6xLil1E=",
+        "linux_arm64": "sha256-uUiiqdb/LU3ezDlqhL6GBogLn7wOinQKnabE3vryXok=",
     },
 }


### PR DESCRIPTION
I'm currently experiencing this error when I tried setting up `rules_apko` locally. 

```
ERROR: User/Dev/bazel-monorepo/WORKSPACE.bazel:487:25: fetching apko_repositories rule //external:apko_darwin_arm64: Traceback (most recent call last):
        File "/private/var/tmp/_bazel_user/82451c28c0803a6357e2fc0181c91a49/external/rules_apko/apko/repositories.bzl", line 56, column 40, in _apko_repo_impl
                repository_ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://github.com/thesayyn/apko/releases/download/v0.0.0/apko_0.0.0_darwin_arm64.tar.gz] to /private/var/tmp/_bazel_User/82451c28c0803a6357e2fc0181c91a49/external/apko_darwin_arm64/temp13831384609312796342/apko_0.0.0_darwin_arm64.tar.gz: Checksum was 397f12f138e255e9ef73bd4231646a64cfc928e22d4de2b12d8938f074d8f26d but wanted 902668329a29e1554f88554925556178bd5a5969813b5d6edcb8942e6713f77a
ERROR: User/Dev/bazel-monorepo/tools/oci_images/node_js_base_image/BUILD.bazel:8:11: //tools/oci_images/node_js_base_image:node_js_base_image depends on @apko_darwin_arm64//:apko_toolchain in repository @apko_darwin_arm64 which failed to fetch. no such package '@apko_darwin_arm64//': java.io.IOException: Error downloading [https://github.com/thesayyn/apko/releases/download/v0.0.0/apko_0.0.0_darwin_arm64.tar.gz] to /private/var/tmp/_bazel_User/82451c28c0803a6357e2fc0181c91a49/external/apko_darwin_arm64/temp13831384609312796342/apko_0.0.0_darwin_arm64.tar.gz: Checksum was 397f12f138e255e9ef73bd4231646a64cfc928e22d4de2b12d8938f074d8f26d but wanted 902668329a29e1554f88554925556178bd5a5969813b5d6edcb8942e6713f77a
```

I believe the issue happened because the SHAs in `version.bzl` are not matching with the SHAs in the [release page of APKO](https://github.com/thesayyn/apko/releases/tag/v0.0.0). 

I believe that the real fix should be on `Apko` side to release different versions instead of updating a SHA. Given that both projects are still at v0, I'm not sure what's the best way of doing this instead of creating a PR and update the SHA here. 

Can you please provide a recommended solution, so updating `version.bzl` is no longer needed when APKO updates? Thank you