### PR TITLE
Do not depend on the alpine/edge (as resolved artifacts are dangling).

### DIFF
--- a/e2e/smoke/README.md
+++ b/e2e/smoke/README.md
@@ -1,5 +1,5 @@
 # smoke test
 
-This e2e exercises the repo from an end-users perpective.
+This e2e exercises the repo from an end-users perspective.
 It catches mistakes in our install instructions, or usages that fail when called from an "external" repository to rules_apko.
 It is also used by the presubmit check for the Bazel Central Registry.

--- a/e2e/smoke/apko.resolved.json
+++ b/e2e/smoke/apko.resolved.json
@@ -4,46 +4,46 @@
     "keyring": [],
     "repositories": [
       {
-        "name": "dl-cdn.alpinelinux.org/alpine/edge/main/x86_64",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz",
+        "name": "dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz",
         "architecture": "x86_64"
       }
     ],
     "packages": [
       {
         "name": "musl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/musl-1.2.4_git20230717-r3.apk",
-        "version": "1.2.4_git20230717-r3",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/musl-1.2.4-r2.apk",
+        "version": "1.2.4-r2",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-NNQ75vr/hK4jV2vPfqjHBLXY/TM="
+          "range": "bytes=0-666",
+          "checksum": "sha1-MiA7YiamUyscxmdGiRBGiJjcW8U="
         },
         "control": {
-          "range": "bytes=665-1230",
-          "checksum": "sha1-mG43yRO1rMNfnDquG8JNnxoYTo8="
+          "range": "bytes=667-1224",
+          "checksum": "sha1-odtIYtKyOCg6suF/cDaYpygL7hw="
         },
         "data": {
-          "range": "bytes=1231-667648",
-          "checksum": "sha256-ORxgfIRz5cUD3/rXyYZEjCstaJLVkRenlWO+wP5AjTE="
+          "range": "bytes=1225-634880",
+          "checksum": "sha256-KPwSgRdeAcnVvczowX1F54Aszov9ZI1cRXgtFZzepfg="
         }
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/busybox-1.36.1-r13.apk",
-        "version": "1.36.1-r13",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-oH8hu95JyOShO0oPRBI3ZPlsc8c="
+          "checksum": "sha1-oXF25kDE6Jja1iQ2psyt9nV+ddE="
         },
         "control": {
-          "range": "bytes=666-2298",
-          "checksum": "sha1-sjQ/UUfq8kIct0jBd/Kn9xTGfrk="
+          "range": "bytes=666-2301",
+          "checksum": "sha1-aBWv1Kn2ASOLShUeDPoSLaozuMs="
         },
         "data": {
-          "range": "bytes=2299-946176",
-          "checksum": "sha256-1+CUivTOQwYueQba2+pigHUw2TwBErH4xehbc2TYkFQ="
+          "range": "bytes=2302-946176",
+          "checksum": "sha256-pDdzepugl8LYISmpJ2wGr885gfpwo2hi9ZMf4dQTi5s="
         }
       }
     ]

--- a/e2e/smoke/apko.yaml
+++ b/e2e/smoke/apko.yaml
@@ -1,6 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.18/main
   packages:
     - busybox
 

--- a/examples/lock/apko.resolved.json
+++ b/examples/lock/apko.resolved.json
@@ -4,46 +4,46 @@
     "keyring": [],
     "repositories": [
       {
-        "name": "dl-cdn.alpinelinux.org/alpine/edge/main/x86_64",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz",
+        "name": "dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz",
         "architecture": "x86_64"
       }
     ],
     "packages": [
       {
         "name": "musl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/musl-1.2.4_git20230717-r3.apk",
-        "version": "1.2.4_git20230717-r3",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/musl-1.2.4-r2.apk",
+        "version": "1.2.4-r2",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-NNQ75vr/hK4jV2vPfqjHBLXY/TM="
+          "range": "bytes=0-666",
+          "checksum": "sha1-MiA7YiamUyscxmdGiRBGiJjcW8U="
         },
         "control": {
-          "range": "bytes=665-1230",
-          "checksum": "sha1-mG43yRO1rMNfnDquG8JNnxoYTo8="
+          "range": "bytes=667-1224",
+          "checksum": "sha1-odtIYtKyOCg6suF/cDaYpygL7hw="
         },
         "data": {
-          "range": "bytes=1231-667648",
-          "checksum": "sha256-ORxgfIRz5cUD3/rXyYZEjCstaJLVkRenlWO+wP5AjTE="
+          "range": "bytes=1225-634880",
+          "checksum": "sha256-KPwSgRdeAcnVvczowX1F54Aszov9ZI1cRXgtFZzepfg="
         }
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/busybox-1.36.1-r13.apk",
-        "version": "1.36.1-r13",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-oH8hu95JyOShO0oPRBI3ZPlsc8c="
+          "checksum": "sha1-oXF25kDE6Jja1iQ2psyt9nV+ddE="
         },
         "control": {
-          "range": "bytes=666-2298",
-          "checksum": "sha1-sjQ/UUfq8kIct0jBd/Kn9xTGfrk="
+          "range": "bytes=666-2301",
+          "checksum": "sha1-aBWv1Kn2ASOLShUeDPoSLaozuMs="
         },
         "data": {
-          "range": "bytes=2299-946176",
-          "checksum": "sha256-1+CUivTOQwYueQba2+pigHUw2TwBErH4xehbc2TYkFQ="
+          "range": "bytes=2302-946176",
+          "checksum": "sha256-pDdzepugl8LYISmpJ2wGr885gfpwo2hi9ZMf4dQTi5s="
         }
       }
     ]

--- a/examples/lock/apko.yaml
+++ b/examples/lock/apko.yaml
@@ -1,9 +1,8 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.18/main
   packages:
     - busybox
-
 
 # optional environment configuration
 environment:
@@ -15,10 +14,9 @@ cmd: /bin/sh -l
 # in the image
 os-release:
   id: alpine
-  version-id: '3.16.0'
-  name: 'Alpine Slim'
-  pretty-name: 'Alpine Slim (apko)'
+  version-id: "3.16.0"
+  name: "Alpine Slim"
+  pretty-name: "Alpine Slim (apko)"
 
 archs:
   - amd64
-  

--- a/examples/multi_arch_and_repo/apko.resolved.json
+++ b/examples/multi_arch_and_repo/apko.resolved.json
@@ -4,1609 +4,1501 @@
     "keyring": [],
     "repositories": [
       {
-        "name": "dl-cdn.alpinelinux.org/alpine/edge/main/aarch64",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/APKINDEX.tar.gz",
+        "name": "dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz",
         "architecture": "aarch64"
       },
       {
-        "name": "dl-cdn.alpinelinux.org/alpine/edge/community/aarch64",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/community/aarch64/APKINDEX.tar.gz",
+        "name": "dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz",
         "architecture": "aarch64"
       },
       {
-        "name": "dl-cdn.alpinelinux.org/alpine/edge/main/x86_64",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz",
+        "name": "dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz",
         "architecture": "x86_64"
       },
       {
-        "name": "dl-cdn.alpinelinux.org/alpine/edge/community/x86_64",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz",
+        "name": "dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz",
         "architecture": "x86_64"
       }
     ],
     "packages": [
       {
         "name": "musl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/musl-1.2.4_git20230717-r3.apk",
-        "version": "1.2.4_git20230717-r3",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/musl-1.2.4-r2.apk",
+        "version": "1.2.4-r2",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-sihknDDnESSQ8u64SrzDKA3re00="
+          "range": "bytes=0-667",
+          "checksum": "sha1-M97an5Feok4I4K5NrUK6gu6N1AA="
         },
         "control": {
-          "range": "bytes=665-1224",
-          "checksum": "sha1-oiNbMwId8hYRSdDJikx1up23nDs="
+          "range": "bytes=668-1200",
+          "checksum": "sha1-7P8BixD3p5XTNrKluPuNqaNbDgI="
         },
         "data": {
-          "range": "bytes=1225-741376",
-          "checksum": "sha256-97xid5OTvcel9GGnwsAh1kbGe+BFUeO2Z+2ST7f3Iho="
+          "range": "bytes=1201-675840",
+          "checksum": "sha256-oc2ARBdQ8rsUCumJZrhXTMrUKadLZu9ro+WlTMmt76M="
         }
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/busybox-1.36.1-r13.apk",
-        "version": "1.36.1-r13",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/busybox-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-YgOLqMTxsNt9P+ESUyFmSpoz4JM="
+          "range": "bytes=0-664",
+          "checksum": "sha1-SRo4BX29GAgtZhChITPNWSIv/SA="
         },
         "control": {
-          "range": "bytes=664-2294",
-          "checksum": "sha1-cAYvfHpZsLLPjEXSE2dlSKCOAJo="
+          "range": "bytes=665-2277",
+          "checksum": "sha1-axjuq9ufLpKDzfHRdBdEC71RgfU="
         },
         "data": {
-          "range": "bytes=2295-1056768",
-          "checksum": "sha256-coE14QuvW6tmaVdjHKvSeDyQL+dUfdaS7eiH9avc7AI="
+          "range": "bytes=2278-1048576",
+          "checksum": "sha256-vZgJOE4x2v3ZCyzpZW4jVc9WO5bkjgZMkU/gcqOOrUw="
         }
       },
       {
         "name": "busybox-binsh",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/busybox-binsh-1.36.1-r13.apk",
-        "version": "1.36.1-r13",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/busybox-binsh-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-bZRjxxumXNN8dOxQDlGKD7IhDRA="
+          "range": "bytes=0-662",
+          "checksum": "sha1-jwY9wc/l4z2Wkjfc+YHPi4fFBAs="
         },
         "control": {
-          "range": "bytes=666-1253",
-          "checksum": "sha1-egPhTWku2LuYFIKiEHlCr+zHA2s="
+          "range": "bytes=663-1226",
+          "checksum": "sha1-CezMO1SCAoQM+fzSZD0nnTngx4w="
         },
         "data": {
-          "range": "bytes=1254-8192",
-          "checksum": "sha256-OdEj4Ao2RdXwZpU3qUZ8h8e8k0e1B5uf/zQG1Bc0/sY="
+          "range": "bytes=1227-8192",
+          "checksum": "sha256-tzuIHJhe4F+8yHDjxg5teCjcUNiOs0LUJrjvDKhxWYo="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libcrypto3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libcrypto3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-664",
-          "checksum": "sha1-ZEB9HQC9ecTxUBajUnIYgM+KGq0="
+          "checksum": "sha1-OmhXrPR5x7+sHTz1ruPSBCfAn7I="
         },
         "control": {
-          "range": "bytes=665-1237",
-          "checksum": "sha1-XIrjkOy5ah6vj05n448CS/jJS7g="
+          "range": "bytes=665-1216",
+          "checksum": "sha1-tnZRge4hq6oZeLxX7uNWlz8omZg="
         },
         "data": {
-          "range": "bytes=1238-4329472",
-          "checksum": "sha256-JG+S9bYbK475rftZtlNl11c0KVjSwFbnykVxd51qmUY="
+          "range": "bytes=1217-4329472",
+          "checksum": "sha256-xyrCM5nJmNUT0wNLK5U7c0VS4FKn9TTUo8fb/15r1P8="
         }
       },
       {
         "name": "ca-certificates",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/ca-certificates-20230506-r0.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/ca-certificates-20230506-r0.apk",
         "version": "20230506-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-664",
-          "checksum": "sha1-5he+BdpFgNVLTPPnpsaK9lgSKik="
+          "checksum": "sha1-fIz32qJcugmhmKKw9Qt4jPWsNIg="
         },
         "control": {
           "range": "bytes=665-1570",
-          "checksum": "sha1-oiXlWJpkMQg01kaWyTSAZu2FPXQ="
+          "checksum": "sha1-ueh9A7UhwfUJqrKqr4NB+tlPtrE="
         },
         "data": {
           "range": "bytes=1571-811008",
-          "checksum": "sha256-b3vULRULD44dZp1L1VKn8uN24aeJ2jrEmsUCfcCV33E="
+          "checksum": "sha256-WeOxiGqnwsMP4Zq0wgMlRNXFqRp9j8nnV1CsLioEggg="
         }
       },
       {
         "name": "libmagic",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libmagic-5.45-r1.apk",
-        "version": "5.45-r1",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libmagic-5.45-r0.apk",
+        "version": "5.45-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-X4NmE99kIZ2OQnlcdGELV1oyQ68="
+          "range": "bytes=0-665",
+          "checksum": "sha1-6DQVNdYiYTtRU75oKVxYelTGJEo="
         },
         "control": {
-          "range": "bytes=665-1239",
-          "checksum": "sha1-lBAwOxb9Lftgj5cO5dflHXew7GY="
+          "range": "bytes=666-1225",
+          "checksum": "sha1-hGZ12JeoRNblV+0b8XDbYrdu1vM="
         },
         "data": {
-          "range": "bytes=1240-8671232",
-          "checksum": "sha256-v56iImXToBEn7idzWDlDdsRKqZUY3P9AF5cEUKxFPcM="
+          "range": "bytes=1226-8675328",
+          "checksum": "sha256-e10rDlb9enN7B//BeJuH4FlbMsA8DONu05b9Dw506m4="
         }
       },
       {
         "name": "file",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/file-5.45-r1.apk",
-        "version": "5.45-r1",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/file-5.45-r0.apk",
+        "version": "5.45-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-1lswPWt1R6EY1ln/eFXb8m70viU="
+          "range": "bytes=0-661",
+          "checksum": "sha1-kal2jB65S0cfq4dxCS7GmdC82Ug="
         },
         "control": {
-          "range": "bytes=665-1240",
-          "checksum": "sha1-JxfU1x6yHHuqimUeBnCd2syvUK4="
+          "range": "bytes=662-1220",
+          "checksum": "sha1-Osxuf83vKimsZ82jPOEmLbGSXaE="
         },
         "data": {
-          "range": "bytes=1241-86016",
-          "checksum": "sha256-7h+09APflQbMumUj1K5sS/zMl1A0SYc+CHuRFCvEIIs="
+          "range": "bytes=1221-81920",
+          "checksum": "sha256-Nrg0MeqSMG7q0YFDoMP/QAxTxSvkA8Mm7m0M/9OJdng="
         }
       },
       {
         "name": "bzip2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/bzip2-1.0.8-r6.apk",
-        "version": "1.0.8-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/bzip2-1.0.8-r5.apk",
+        "version": "1.0.8-r5",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-661",
-          "checksum": "sha1-+uBl9dBlfqUwEiW8BQU//df0akc="
+          "range": "bytes=0-666",
+          "checksum": "sha1-WmEqgVQFb4UNxBQb5hQMLb+Fbhg="
         },
         "control": {
-          "range": "bytes=662-1272",
-          "checksum": "sha1-n9JcmQmoBfz40JrGB87nh74TUjI="
+          "range": "bytes=667-1262",
+          "checksum": "sha1-khQhG07XQcWPeLU5spmlodh8ag0="
         },
         "data": {
-          "range": "bytes=1273-516096",
-          "checksum": "sha256-QsNG62FfoP+W+wuI51uh1afoto3ZVq0IXC+ObqqiOp0="
+          "range": "bytes=1263-516096",
+          "checksum": "sha256-nikmMLEOlg0GxMMkHza1o9LShKcJz4FQwto9pRZ0wBI="
         }
       },
       {
         "name": "libbz2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libbz2-1.0.8-r6.apk",
-        "version": "1.0.8-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libbz2-1.0.8-r5.apk",
+        "version": "1.0.8-r5",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-hDMGMQjRgrShwz/F5mI7VU60Jtw="
+          "range": "bytes=0-665",
+          "checksum": "sha1-BbiB17BNuvc0RATUAGbDFJ0Gd0c="
         },
         "control": {
-          "range": "bytes=663-1216",
-          "checksum": "sha1-+ff94+klSZECTsgNO1xBgZ+ym7E="
+          "range": "bytes=666-1205",
+          "checksum": "sha1-GrKOV3zFFUQfWwtvU9EseqJwEfA="
         },
         "data": {
-          "range": "bytes=1217-86016",
-          "checksum": "sha256-Dphhoqvsm+UyMjMeJTHfVnrlguzuneHsXbAyUEBWOV4="
+          "range": "bytes=1206-86016",
+          "checksum": "sha256-A4NHDQ9/hyXQp30tPIrokuTkHS5FQphhQj3ZcIuKr80="
         }
       },
       {
         "name": "libcap2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libcap2-2.69-r1.apk",
-        "version": "2.69-r1",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libcap2-2.69-r0.apk",
+        "version": "2.69-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-GmeZCRuA7KqhHfNS7wTi6x5e8co="
+          "range": "bytes=0-664",
+          "checksum": "sha1-/t3RXU0o9cnziHWYmmNQMVOpuVY="
         },
         "control": {
-          "range": "bytes=666-1281",
-          "checksum": "sha1-Xdm5nUTAvTb94jU4YLqfmaPzjd8="
+          "range": "bytes=665-1272",
+          "checksum": "sha1-LcXjfZn1YrzxTxjOcvhZvy0ERUA="
         },
         "data": {
-          "range": "bytes=1282-151552",
-          "checksum": "sha256-ihyWTWl3hKudGKN8JJxgEtMkgZay+8MUCJS3BE9G4Lg="
+          "range": "bytes=1273-151552",
+          "checksum": "sha256-nzsIZV3r9S8PIcCDESF8ZAOm6EQp4X2qvbAZg5IPtf4="
         }
       },
       {
         "name": "zlib",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/zlib-1.3-r0.apk",
-        "version": "1.3-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/zlib-1.2.13-r1.apk",
+        "version": "1.2.13-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-V5C8sGOajyCae3csMRB6vn9LHeI="
+          "range": "bytes=0-667",
+          "checksum": "sha1-6NOhgZe0PJP0CFhhzF0ZF/Ovhxw="
         },
         "control": {
-          "range": "bytes=665-1209",
-          "checksum": "sha1-PvfyDRSoGShWtUkM97uGlUZcv80="
+          "range": "bytes=668-1199",
+          "checksum": "sha1-W9bNRsvWY9M6bK1xczGEXAHIID4="
         },
         "data": {
-          "range": "bytes=1210-143360",
-          "checksum": "sha256-r1aeCDjfSCAa6/O+aiBodU8mpRKIS/lSlqn7q8nenFc="
+          "range": "bytes=1200-143360",
+          "checksum": "sha256-vp9rkyehsDhH3RvRJp8hcuTlzPJ6EXftX746L1vOviQ="
         }
       },
       {
         "name": "cdrkit",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/community/aarch64/cdrkit-1.1.11-r6.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/cdrkit-1.1.11-r6.apk",
         "version": "1.1.11-r6",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-C7g4AZIwIKQlWHIm3gSm2EJ2SYM="
+          "range": "bytes=0-662",
+          "checksum": "sha1-ciyNpZ0mcCSOu9FuSlgDcLazM08="
         },
         "control": {
-          "range": "bytes=665-1406",
-          "checksum": "sha1-fOR6FgU0Wpdw6JSlrxyd/E9DqPA="
+          "range": "bytes=663-1407",
+          "checksum": "sha1-qfrsSo6S6iX6tMs6KAdKFEBY0Tc="
         },
         "data": {
-          "range": "bytes=1407-2932736",
-          "checksum": "sha256-WFslnDKd2QO1GCBIWQJZ9CAVgHoCXhDNTl0D8webnvk="
+          "range": "bytes=1408-2932736",
+          "checksum": "sha256-5vWZUmZ/UTumHQHsevVFIKB0eDZAoK8xjyEPZc1wyks="
         }
       },
       {
         "name": "brotli-libs",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/brotli-libs-1.1.0-r0.apk",
-        "version": "1.1.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/brotli-libs-1.0.9-r14.apk",
+        "version": "1.0.9-r14",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-667",
-          "checksum": "sha1-l9QT1+u+B/zdpzN7VmI+N5CbpWY="
+          "range": "bytes=0-664",
+          "checksum": "sha1-roldnE+jPD0iQu0QNVu/XQ3jZ8A="
         },
         "control": {
-          "range": "bytes=668-1251",
-          "checksum": "sha1-PHi3EFZoXoH5/WufzlduuM8M7Aw="
+          "range": "bytes=665-1254",
+          "checksum": "sha1-GqHglHKFSbAS6K19zYvHBlbvgnw="
         },
         "data": {
-          "range": "bytes=1252-942080",
-          "checksum": "sha256-Zwp0okaSbA4/31aNI5nwCptHQz3hNY7AdeUS5EsXSnk="
-        }
-      },
-      {
-        "name": "c-ares",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/c-ares-1.20.1-r0.apk",
-        "version": "1.20.1-r0",
-        "architecture": "aarch64",
-        "signature": {
-          "range": "bytes=0-661",
-          "checksum": "sha1-vtQLD8k49gcbrZ1yDnygtpJCLlg="
-        },
-        "control": {
-          "range": "bytes=662-1222",
-          "checksum": "sha1-J9UOprUywdguNUjAEsLGPg6b3ZE="
-        },
-        "data": {
-          "range": "bytes=1223-147456",
-          "checksum": "sha256-5bYOUfC/QB2DO/03bj9PB7w2jeSLEyuZ6Rvbj51qSTI="
+          "range": "bytes=1255-811008",
+          "checksum": "sha256-KFFq58f22V27LG8xthwRUzzAP2Pp/Q4ACMJJoJ9BArs="
         }
       },
       {
         "name": "libunistring",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libunistring-1.1-r2.apk",
-        "version": "1.1-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libunistring-1.1-r1.apk",
+        "version": "1.1-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-sgpMT0o4Ufl0nl1yTtHIof01/0A="
+          "range": "bytes=0-665",
+          "checksum": "sha1-729xqeI421Pz1Uy5DqVpifAMEUY="
         },
         "control": {
-          "range": "bytes=664-1261",
-          "checksum": "sha1-3ex6eSauJ0tUR4qHgZdiEhRCQMc="
+          "range": "bytes=666-1267",
+          "checksum": "sha1-pCg8fZa818UnB/TOw6weB0Qprv4="
         },
         "data": {
-          "range": "bytes=1262-1720320",
-          "checksum": "sha256-Ho4ZydLzxdfOeA/ACnEn4T+5USx7Elmrz1hydqeeTWI="
+          "range": "bytes=1268-1785856",
+          "checksum": "sha256-1HvsJ4TOoFain9bXo5XojT6TMyTdIZM/XGIUFbm8EEQ="
         }
       },
       {
         "name": "libidn2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libidn2-2.3.4-r4.apk",
-        "version": "2.3.4-r4",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libidn2-2.3.4-r1.apk",
+        "version": "2.3.4-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-DUsSnI+TfMkFJORSWBdHXu3l1mU="
+          "range": "bytes=0-665",
+          "checksum": "sha1-Q/asSOANbtRpGFisToqTppVB+zs="
         },
         "control": {
-          "range": "bytes=664-1276",
-          "checksum": "sha1-ljbXpFVG2ZWumOI9E4CvQSpQ9BI="
+          "range": "bytes=666-1286",
+          "checksum": "sha1-soFtyuiGGMleboIW6A9Alo6W9YI="
         },
         "data": {
-          "range": "bytes=1277-212992",
-          "checksum": "sha256-Rj4m0q/SQALG4GjNL9k5rCdz3NMV79c0tMZhVuLBY9w="
+          "range": "bytes=1287-212992",
+          "checksum": "sha256-0MBJm2Yi3Y/f6g4tec59HKrbZ9mcSAbBSjMzkBV2wTQ="
         }
       },
       {
         "name": "nghttp2-libs",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/nghttp2-libs-1.57.0-r0.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/nghttp2-libs-1.57.0-r0.apk",
         "version": "1.57.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-666",
-          "checksum": "sha1-S7wAHY/B2NEgPGZb5UvfdSAJioE="
+          "range": "bytes=0-663",
+          "checksum": "sha1-NHbYrgMd8HLcP7ltuAAD8JzkNQY="
         },
         "control": {
-          "range": "bytes=667-1239",
-          "checksum": "sha1-64e2/WqDedpgrOHEQC2wtXrPX3E="
+          "range": "bytes=664-1232",
+          "checksum": "sha1-Uu/enQwHtQkxQnHt3TllpCzyq9U="
         },
         "data": {
-          "range": "bytes=1240-212992",
-          "checksum": "sha256-d6yMFf8ruRoPpFOBaEtaZ9/slqhNaoFeBVP4M9qG8yA="
+          "range": "bytes=1233-212992",
+          "checksum": "sha256-Z8T1VxGDpQnqwY1RAvSn43HX9sjpBljvtxwlP+Rp7F0="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libssl3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libssl3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-gAgishadBB2fVzDcEBle3+6v+Ws="
+          "range": "bytes=0-664",
+          "checksum": "sha1-QispGeBQui0CrWyKfdStKqfDJIs="
         },
         "control": {
-          "range": "bytes=664-1237",
-          "checksum": "sha1-0t8NvMBc8KqbfS01jZViN++UQXU="
+          "range": "bytes=665-1219",
+          "checksum": "sha1-i9saQj0KGMucXXqYl9odFh3Rp0k="
         },
         "data": {
-          "range": "bytes=1238-622592",
-          "checksum": "sha256-+wbjN7FABhfDq5at/ESdywgoxEavmz0VNvIzot6bHd0="
+          "range": "bytes=1220-622592",
+          "checksum": "sha256-+2kj8KV9ZaIuQY65TQvM5go6Tnd/wwtfAd9dstIWaZA="
         }
       },
       {
         "name": "libcurl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libcurl-8.4.0-r0.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libcurl-8.4.0-r0.apk",
         "version": "8.4.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-H9CmkzJwzLeb+RJrtMzQMpqnPRU="
+          "range": "bytes=0-667",
+          "checksum": "sha1-+qUfnAHSeI3WSmgYuP6Zkb3dtrI="
         },
         "control": {
-          "range": "bytes=665-1278",
-          "checksum": "sha1-SDtWeCF6K0sqPkQLue0e4M+3+OI="
+          "range": "bytes=668-1257",
+          "checksum": "sha1-gPf4xljVT4LCLL/LacYdcuDId28="
         },
         "data": {
-          "range": "bytes=1279-618496",
-          "checksum": "sha256-MyeDBO9Hzyu+sYFeiMLU2zsoz3WWuxLq9u5kdweAfQk="
+          "range": "bytes=1258-684032",
+          "checksum": "sha256-qNyxFzcgWmzhqd6p4ag/FFrwttjNyM+ZDmay1JCtdrA="
         }
       },
       {
         "name": "ssl_client",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/ssl_client-1.36.1-r13.apk",
-        "version": "1.36.1-r13",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/ssl_client-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-f3E7a0Iwst7UGU7RdC82hfc+R6g="
+          "range": "bytes=0-661",
+          "checksum": "sha1-Jv1c6zR9y5SaeJdUfr2+XEmQQPg="
         },
         "control": {
-          "range": "bytes=666-1293",
-          "checksum": "sha1-U/LE0P0/UZrpTJs0irCOANkLgso="
+          "range": "bytes=662-1265",
+          "checksum": "sha1-In3mePI6q90ybQZMHRPbZKuw3UI="
         },
         "data": {
-          "range": "bytes=1294-81920",
-          "checksum": "sha256-Eme52KMUOtnzIgbtUQKHyIkSigV/cvdV+5sjPWnOtoU="
+          "range": "bytes=1266-81920",
+          "checksum": "sha256-Owfbqb6vWOzSgSYFAH+vG52eqAIOWp6F1XrJAzvxURQ="
         }
       },
       {
         "name": "curl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/curl-8.4.0-r0.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/curl-8.4.0-r0.apk",
         "version": "8.4.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-HjiJKnwN58cfzESuGJLI7lli3GA="
+          "range": "bytes=0-662",
+          "checksum": "sha1-tHlf9OQOzSjYkTRXYsBdF1ns/jk="
         },
         "control": {
-          "range": "bytes=665-1228",
-          "checksum": "sha1-EQ1Hb88//7acF9Ul/aLhqpYxDSM="
+          "range": "bytes=663-1208",
+          "checksum": "sha1-NJnlr4Up2hhq7YnlXBVFST5wEiM="
         },
         "data": {
-          "range": "bytes=1229-278528",
-          "checksum": "sha256-yyXHD+OMq68wazILCAipK/UQwq+rYHeaRieFmd4Vogg="
+          "range": "bytes=1209-278528",
+          "checksum": "sha256-ENmDbt7laYTIqVbFBIqIqi2a1pGZTmYEvSWt9T9XtXw="
         }
       },
       {
         "name": "libmnl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libmnl-1.0.5-r2.apk",
-        "version": "1.0.5-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libmnl-1.0.5-r1.apk",
+        "version": "1.0.5-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-QVFWBvanA4vCXcquijtwJJUq6NM="
+          "checksum": "sha1-ZAJGwqf/dX12Y3VyDB4LK2MSHVg="
         },
         "control": {
-          "range": "bytes=666-1244",
-          "checksum": "sha1-JQiZbwsFl8cGYLgrCAUt4K4vl7M="
+          "range": "bytes=666-1250",
+          "checksum": "sha1-fd1oi4lE0zAv5U9gLgiDvABv2b4="
         },
         "data": {
-          "range": "bytes=1245-81920",
-          "checksum": "sha256-xzNocZTsZvA4S4c16ZBTqBs+xkgzIzILlf/II4iOf+k="
+          "range": "bytes=1251-81920",
+          "checksum": "sha256-1S1SXXIJi/htQsdET49Wpzr7CGuKYfzbjgxvLClAPbY="
         }
       },
       {
         "name": "ethtool",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/ethtool-6.5-r0.apk",
-        "version": "6.5-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/ethtool-6.2-r1.apk",
+        "version": "6.2-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-BScgWOW4/t8KmRHbdLwH8q75Sb0="
+          "range": "bytes=0-664",
+          "checksum": "sha1-0M1fulAERsEGLjtiDJLXvu/Wv3Y="
         },
         "control": {
-          "range": "bytes=663-1266",
-          "checksum": "sha1-4sldiAiSoaV8aT+LifEGZFlzdI0="
+          "range": "bytes=665-1271",
+          "checksum": "sha1-EpPATdUQ6gBxSfuE2B7nevuftqA="
         },
         "data": {
-          "range": "bytes=1267-606208",
-          "checksum": "sha256-ND+Ev4p9ZqFbD1exzNe4/nn7Nf0AGRo9nOKZomnwFrA="
+          "range": "bytes=1272-606208",
+          "checksum": "sha256-N2KiVaELN1SjxaEe2vMH2E4p+3ekgcY6jsFty1AkyJ8="
         }
       },
       {
         "name": "libexpat",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libexpat-2.5.0-r2.apk",
-        "version": "2.5.0-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libexpat-2.5.0-r1.apk",
+        "version": "2.5.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-AXoinK2z2TiLkXmXBF39n6c/vck="
+          "range": "bytes=0-666",
+          "checksum": "sha1-oJXCvXRm3Gjj/s1g6Pp6GjtG4ao="
         },
         "control": {
-          "range": "bytes=663-1235",
-          "checksum": "sha1-FyC6nimAwGM1Qm9Ukcb8ClTiq10="
+          "range": "bytes=667-1244",
+          "checksum": "sha1-t9VROseUEXD/1E9OirJTjlW5Nzw="
         },
         "data": {
-          "range": "bytes=1236-212992",
-          "checksum": "sha256-7E1u5KMVdjRa3h9E9R8EWOseXRk+GQHdBEPoqor+cbc="
+          "range": "bytes=1245-212992",
+          "checksum": "sha256-WATJwTAaw0g+f03d+gFtgExcSS2Ox+1Qk7gu+BTExgI="
         }
       },
       {
         "name": "pcre2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/pcre2-10.42-r1.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/pcre2-10.42-r1.apk",
         "version": "10.42-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-xUtNbJMsRI0Q0UGsjz/KMdByuVw="
+          "range": "bytes=0-663",
+          "checksum": "sha1-p3fvMsvYRdnp8IMUuY8GH+l4JL8="
         },
         "control": {
-          "range": "bytes=665-1248",
-          "checksum": "sha1-q1L2e3+3fzHkN/u/FPtLzgQ5c3Y="
+          "range": "bytes=664-1255",
+          "checksum": "sha1-WOeY+ZB9fRnUwWMSusto4+BrsTI="
         },
         "data": {
-          "range": "bytes=1249-675840",
-          "checksum": "sha256-JjOvh64DnIFHCXGXf8yEtC5vqXfoCnR5IAyXJ0oZP50="
+          "range": "bytes=1256-675840",
+          "checksum": "sha256-a11ccezRWzJ2e2ovEPH7FfjYEkSgJju/eFAh6H/HVNo="
         }
       },
       {
         "name": "git",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/git-2.42.0-r0.apk",
-        "version": "2.42.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/git-2.40.1-r0.apk",
+        "version": "2.40.1-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-jkAKunWThTWWZtXzRFQC9BGJVWI="
+          "range": "bytes=0-667",
+          "checksum": "sha1-2lhOv3IVoX0CRGFliWrHf7TdosM="
         },
         "control": {
-          "range": "bytes=665-1284",
-          "checksum": "sha1-TI9v4JclUFWRvZgM45F9BEQC0y0="
+          "range": "bytes=668-1292",
+          "checksum": "sha1-YSAUbyToGdFkrDRC0i0igzHiALE="
         },
         "data": {
-          "range": "bytes=1285-6631424",
-          "checksum": "sha256-u5h4W5YD43w9dlDQEPldWErpcYva5iHPMYNbb8d2wu0="
+          "range": "bytes=1293-6496256",
+          "checksum": "sha256-jbqP8o9gx5aeVNzl0M+gxqYKdmBT7ggmU7PR9X8rtmI="
         }
       },
       {
         "name": "oniguruma",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/oniguruma-6.9.9-r0.apk",
-        "version": "6.9.9-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/oniguruma-6.9.8-r1.apk",
+        "version": "6.9.8-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-667",
-          "checksum": "sha1-zAOvTrZL7e+BpODfM1zcZhNFBCM="
+          "range": "bytes=0-665",
+          "checksum": "sha1-zk1We5yyIli9ZiRpMqA4IBZFl8Y="
         },
         "control": {
-          "range": "bytes=668-1239",
-          "checksum": "sha1-sV3aScYVGNfUWTMJ2aD30gOSkb8="
+          "range": "bytes=666-1243",
+          "checksum": "sha1-btq9Y5uq8wvHfyRwjsQvFsxmlCA="
         },
         "data": {
-          "range": "bytes=1240-630784",
-          "checksum": "sha256-HRVUFbdh4E8bztkVDehdR51zhrdaYQcF3G4krkzG0dQ="
+          "range": "bytes=1244-630784",
+          "checksum": "sha256-d2YEVbl/R88KbKGprdhbAKxZp58994j5PkNw5WdntoA="
         }
       },
       {
         "name": "jq",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/jq-1.7-r2.apk",
-        "version": "1.7-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/jq-1.6-r3.apk",
+        "version": "1.6-r3",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-667",
-          "checksum": "sha1-zZdJjcWVMtQ+cH0DgmZbvunRNEA="
+          "range": "bytes=0-663",
+          "checksum": "sha1-A4nhkN/96UgBJbIeQnerGNiDcTQ="
         },
         "control": {
-          "range": "bytes=668-1264",
-          "checksum": "sha1-asKGAIic2GuwNXTi2SU+3BSrt1M="
+          "range": "bytes=664-1276",
+          "checksum": "sha1-bE8DJ2EMXuuIQJu6heONhhH6n3A="
         },
         "data": {
-          "range": "bytes=1265-679936",
-          "checksum": "sha256-miuZNtiug58fQeuHUwYQe7Adc0KpzPqFKLzH5aDVkI4="
+          "range": "bytes=1277-679936",
+          "checksum": "sha256-gqEeVd61YkdNuzcO8xTYSM2AKPAFmRyoBrrvrtKAAZI="
         }
       },
       {
         "name": "ncurses-terminfo-base",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/ncurses-terminfo-base-6.4_p20231007-r0.apk",
-        "version": "6.4_p20231007-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/ncurses-terminfo-base-6.4_p20230506-r0.apk",
+        "version": "6.4_p20230506-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-CFjrR4ZT66CdwFtU1Tc5LzegwFg="
+          "range": "bytes=0-664",
+          "checksum": "sha1-RxPlTUbe33NeZ61osP37DUwhXIw="
         },
         "control": {
-          "range": "bytes=666-1204",
-          "checksum": "sha1-RoIJUREPKGEMz8qQ4t8u5VcHz+g="
+          "range": "bytes=665-1209",
+          "checksum": "sha1-P9b2GeAXWbCKucBeLU4uahKobtw="
         },
         "data": {
-          "range": "bytes=1205-217088",
-          "checksum": "sha256-maJwG/s0B6MBTwHzAE9Jmuy4Yp5D2paeE+ylP4RAd58="
+          "range": "bytes=1210-221184",
+          "checksum": "sha256-ME8ljS2m7hdG1gEJ9mzc6Lk9/JuAd5x+sMLP8bFZ0BM="
         }
       },
       {
         "name": "libncursesw",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libncursesw-6.4_p20231007-r0.apk",
-        "version": "6.4_p20231007-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libncursesw-6.4_p20230506-r0.apk",
+        "version": "6.4_p20230506-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-667",
-          "checksum": "sha1-XoYFbyrpfrua1C4WAyJglRt5k/M="
+          "checksum": "sha1-jSbo9NYinx+K9L+Vcc4uxrUe7Wk="
         },
         "control": {
-          "range": "bytes=668-1258",
-          "checksum": "sha1-4i3IIL1mCvsg6lQJLKIdigOQwEM="
+          "range": "bytes=668-1263",
+          "checksum": "sha1-eUFQGB0cP3hy7sXMgCTFyJ/pn4c="
         },
         "data": {
-          "range": "bytes=1259-409600",
-          "checksum": "sha256-tM1xTpriN0SR1JiXqFKkuMbw9iP7yXfM3McYjwMQTXs="
+          "range": "bytes=1264-409600",
+          "checksum": "sha256-yjcwPQEI0eoTnr/vTDeQf09U1WYaIvVEGXN8dZ8OMLY="
         }
       },
       {
         "name": "less",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/less-643-r1.apk",
-        "version": "643-r1",
-        "architecture": "aarch64",
-        "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-W4+YAR7RrpKTEfeoxiFWCwGSc/s="
-        },
-        "control": {
-          "range": "bytes=665-1262",
-          "checksum": "sha1-mdK6yaeUbs8ysPOZyPlwoUuauOs="
-        },
-        "data": {
-          "range": "bytes=1263-368640",
-          "checksum": "sha256-cgl1JicVLVNIyVvQvlZ40B82D244g+tGgVpJfSr1tcQ="
-        }
-      },
-      {
-        "name": "musl-obstack",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/musl-obstack-1.2.3-r2.apk",
-        "version": "1.2.3-r2",
-        "architecture": "aarch64",
-        "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-tUx53sJwKGu5dFS1S4eyZE+V/CU="
-        },
-        "control": {
-          "range": "bytes=663-1255",
-          "checksum": "sha1-zP61PCnxJII3zfQbkTRlwFnrJsA="
-        },
-        "data": {
-          "range": "bytes=1256-81920",
-          "checksum": "sha256-930v2Z4kyen1e3+YJ8952tHUuXWC56m0c0EFMtA2Crc="
-        }
-      },
-      {
-        "name": "libucontext",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libucontext-1.2-r2.apk",
-        "version": "1.2-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/less-633-r0.apk",
+        "version": "633-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-Wbc7dydSLzf4gBUmmxAaLFk7RII="
+          "checksum": "sha1-XMa9fAHZIuRpr9yunuNjgasvsu0="
         },
         "control": {
-          "range": "bytes=666-1246",
-          "checksum": "sha1-SujvfarP2t90n2+6SeDGN7nv7Og="
+          "range": "bytes=666-1268",
+          "checksum": "sha1-kv2pQ60yGXnSuBf441pz9UKeeKs="
         },
         "data": {
-          "range": "bytes=1247-147456",
-          "checksum": "sha256-4UuDMTZABlya/twt0biTxJmmEgFXkyOkZUYTO3ShTQM="
+          "range": "bytes=1269-368640",
+          "checksum": "sha256-tENLVv3bqP0/BuEpsqyBbu5rl5eIU1/bpOidXjSUHKE="
         }
       },
       {
-        "name": "gcompat",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/gcompat-1.1.0-r4.apk",
-        "version": "1.1.0-r4",
+        "name": "libc6-compat",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libc6-compat-1.2.4-r2.apk",
+        "version": "1.2.4-r2",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-Z2/TdevUenXjLzZgEWQb7ma14zc="
+          "range": "bytes=0-666",
+          "checksum": "sha1-MrHEMaMS6RNGBE2D72CfGA43JHY="
         },
         "control": {
-          "range": "bytes=666-1280",
-          "checksum": "sha1-vd84iRbIP5YkR3N5nF5v4pkqq7A="
+          "range": "bytes=667-1184",
+          "checksum": "sha1-B9/eTkolvAIinO0RCkLLU1zVN+k="
         },
         "data": {
-          "range": "bytes=1281-151552",
-          "checksum": "sha256-yzVVfE4EULM2Oy82X4jOFmdxK7iOx5ihcqgAKcvQbz8="
+          "range": "bytes=1185-8192",
+          "checksum": "sha256-sNCNpMJAP03rWZju24MdDZyiI0HmKmGzNKIvuivHQ8M="
         }
       },
       {
         "name": "openssh-keygen",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssh-keygen-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/openssh-keygen-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-o2FQ0JRwiRE8SY6ZgW1qCOYBngk="
+          "range": "bytes=0-662",
+          "checksum": "sha1-oEfrkJi6nXEvTyKIF7o2yKCt10k="
         },
         "control": {
-          "range": "bytes=664-1265",
-          "checksum": "sha1-eTq24kfV2K1ythDrNGR302HWxEQ="
+          "range": "bytes=663-1242",
+          "checksum": "sha1-pOO+rafv2IZBUxswTZXs2EbGMnI="
         },
         "data": {
-          "range": "bytes=1266-671744",
-          "checksum": "sha256-x+2cNOuK8mabdRK0ddmbKyg2TfpgFNnXHmmUdt9zLeQ="
+          "range": "bytes=1243-671744",
+          "checksum": "sha256-5SEu4nZtftxASlHYoFtWWmoPOV/ARkjauQ0aMj1xWCE="
         }
       },
       {
         "name": "libedit",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/libedit-20230828.3.1-r3.apk",
-        "version": "20230828.3.1-r3",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libedit-20221030.3.1-r1.apk",
+        "version": "20221030.3.1-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-GtKpy5IpMoCk3EVf1kQJcNdvwo0="
+          "checksum": "sha1-Ia4lkYC/zP5fl9bmStUfPsisjFk="
         },
         "control": {
-          "range": "bytes=666-1239",
-          "checksum": "sha1-YNHGo/OQMg0hEvhA9617OqlOb6Q="
+          "range": "bytes=666-1250",
+          "checksum": "sha1-BJfMVxvYuXt5PYaJReMEFd3ZetM="
         },
         "data": {
-          "range": "bytes=1240-278528",
-          "checksum": "sha256-XGTZv4F39as8HpitzLKqUrqMYYz0/4AphGVLJy/ND/E="
+          "range": "bytes=1251-278528",
+          "checksum": "sha256-Jg+qJ8o3EoiE0xzIbWYcjNXb6LTPOxqAWAS3EMfj73o="
         }
       },
       {
         "name": "openssh-client-common",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssh-client-common-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/openssh-client-common-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-Uh3xIPgryaL6YFft9qkPXUYEe0g="
+          "range": "bytes=0-662",
+          "checksum": "sha1-7fELRC5T9v1aeNUdY9bzxEEKRQk="
         },
         "control": {
-          "range": "bytes=665-1331",
-          "checksum": "sha1-b6HyUlrVM3uxNcFKLX9MSNhxCOI="
+          "range": "bytes=663-1308",
+          "checksum": "sha1-qDQTFQt8Q0Y3Z1bnyczxUnBqn7g="
         },
         "data": {
-          "range": "bytes=1332-3239936",
-          "checksum": "sha256-POcZ/D6RblIx5CRtBRllVRJwgW1GBmr4qoHPuvrLAKU="
+          "range": "bytes=1309-3223552",
+          "checksum": "sha256-xSOfvPGW5qjVeXjY9Utm70FBilBWdj2mcxLqOrBDEak="
         }
       },
       {
         "name": "openssh-client-default",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssh-client-default-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/openssh-client-default-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-BeWxCn+lHWfJTvOFYJWBnxp12h0="
+          "range": "bytes=0-661",
+          "checksum": "sha1-aDBAA9trZbZ1Mw0aC499MHt6pK8="
         },
         "control": {
-          "range": "bytes=666-1295",
-          "checksum": "sha1-OJ35zGzxFP7h/8Ua1RzouGEHX2k="
+          "range": "bytes=662-1274",
+          "checksum": "sha1-/dHqp52z4HEpQSbJVQqXKihrvNY="
         },
         "data": {
-          "range": "bytes=1296-999424",
-          "checksum": "sha256-XmqBuh4OvWoRjDd2t0k3HW1cpyBKSWfjZ0Tgi5qtjeU="
+          "range": "bytes=1275-999424",
+          "checksum": "sha256-xYfypEhi6KNKpemx31GDxQGeg9HQAohlUuEbdnw1plo="
         }
       },
       {
         "name": "openssh-sftp-server",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssh-sftp-server-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/openssh-sftp-server-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-GbwgXR8c9a6pk4qPh/cbVvEdAyY="
+          "range": "bytes=0-661",
+          "checksum": "sha1-TqBSZtjW9WPw+TlYpqRHnC7LOiU="
         },
         "control": {
-          "range": "bytes=663-1217",
-          "checksum": "sha1-oV9FuuTQw+y2TQJvP0goFYLN0yc="
+          "range": "bytes=662-1197",
+          "checksum": "sha1-UF1AWeORavZvST+UDIbsxr8TDog="
         },
         "data": {
-          "range": "bytes=1218-217088",
-          "checksum": "sha256-hyY/pmeGxsX7FHp4C4WiPLDKnMZZvwlRsasxWS3vbdQ="
+          "range": "bytes=1198-217088",
+          "checksum": "sha256-ozyop6A4xQKkCsHzpkcKve6aScsOUqu49EL923yCf18="
         }
       },
       {
         "name": "openssh-server-common",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssh-server-common-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/openssh-server-common-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-8vh8vnYMH8LdM40Ah6RWUhuHGEQ="
+          "range": "bytes=0-660",
+          "checksum": "sha1-H9nVNzRs5OLzCRe6kTo+6NMGNIg="
         },
         "control": {
-          "range": "bytes=664-1202",
-          "checksum": "sha1-Etms2VUZDRb1y5hhtxpDE1CZD40="
+          "range": "bytes=661-1184",
+          "checksum": "sha1-vVa8qywBX4Vh1v/iLRqo5DJlHL8="
         },
         "data": {
-          "range": "bytes=1203-20480",
-          "checksum": "sha256-V2hmB8gCVsiIt8C6wErX3+HYy6qkRN/BZ+38v0uvNC0="
+          "range": "bytes=1185-32768",
+          "checksum": "sha256-+4M2P8Kxoxlt38UuJOI0cMF+3kYTNdfOQFdxkbyorMY="
         }
       },
       {
         "name": "openssh-server",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssh-server-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/openssh-server-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-uLFWYyaJqWyX8u3GFqMTep0DMSo="
+          "range": "bytes=0-660",
+          "checksum": "sha1-rA3vECZDHi5A3dWDaFOhJgTVYr0="
         },
         "control": {
-          "range": "bytes=666-1259",
-          "checksum": "sha1-5NGx/t+oOqQsElVVGpOBehLQnOU="
+          "range": "bytes=661-1237",
+          "checksum": "sha1-xBWOlFHTI90yg8XsbskFrVQbex4="
         },
         "data": {
-          "range": "bytes=1260-1064960",
-          "checksum": "sha256-JGsnvgXfzgH3khJPzIHjgPlSTnv33IpkMlE9B+VtEgg="
+          "range": "bytes=1238-1064960",
+          "checksum": "sha256-Lja+MQRdRoEjmejo68vOGfZoLs0OH9tBAUJSaNfOcKA="
         }
       },
       {
         "name": "openssh",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssh-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/openssh-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-r3MOXS+Rtb86SlTrS7gbNPOKnmg="
+          "range": "bytes=0-663",
+          "checksum": "sha1-XMwprNCI5bRRxwcxaWymPA7OaGE="
         },
         "control": {
-          "range": "bytes=665-1256",
-          "checksum": "sha1-mbDlzg0NVcdWznh9eQ09yv2UQQY="
+          "range": "bytes=664-1234",
+          "checksum": "sha1-p6RLRYA/lEBlvIX7t5HiTdggKrw="
         },
         "data": {
-          "range": "bytes=1257-491520",
-          "checksum": "sha256-1gm7qUY8ODTQsaoHE+PboznSaaXmz+WPdrQRVXLVDaA="
+          "range": "bytes=1235-487424",
+          "checksum": "sha256-iBHNk9egYhaeT2Q+EOiYwRbpkEpv9oa/SujVCPiqFtU="
         }
       },
       {
         "name": "openssl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssl-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/openssl-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-wvGG6Q6zS9VlLzKGqRND6rWfKT8="
+          "checksum": "sha1-yfaDAvjJjOVwmjlYUhlDA4yfcww="
         },
         "control": {
-          "range": "bytes=666-1282",
-          "checksum": "sha1-P5WV7mZKYc+goVKvm2ERsmM5UcE="
+          "range": "bytes=666-1265",
+          "checksum": "sha1-mh42b80ilWGgLE58uDOK0r90Bx4="
         },
         "data": {
-          "range": "bytes=1283-905216",
-          "checksum": "sha256-M1TRg/EYfXQgMcsDdVeY4vYLW6r9FEgpLkKoY4zwIm0="
+          "range": "bytes=1266-905216",
+          "checksum": "sha256-xZm+97rZJXeNSRVc9LpijQhtY7uAYurHNOFTNLt957E="
         }
       },
       {
         "name": "unzip",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/unzip-6.0-r14.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/unzip-6.0-r14.apk",
         "version": "6.0-r14",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-PjQz6q0GQdn7b9KRWV3L5zBSXmk="
+          "range": "bytes=0-663",
+          "checksum": "sha1-4YKP/GrMY2EYvrwRA0aD/R0ELB0="
         },
         "control": {
-          "range": "bytes=666-1264",
-          "checksum": "sha1-hHOACMAIHiD+WGwQPb7mTjqk8ls="
+          "range": "bytes=664-1269",
+          "checksum": "sha1-eOsMm9WuKlp+XaSKRIYnwQavr/w="
         },
         "data": {
-          "range": "bytes=1265-421888",
-          "checksum": "sha256-tsARnoKgO0QLK8wayZ3KvQaERtXhPiq0gi5GylUbzEs="
+          "range": "bytes=1270-421888",
+          "checksum": "sha256-gx//gzc8A67qGW3POhL+8BjcmUOau2BafI53y2yNVOA="
         }
       },
       {
         "name": "musl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/musl-1.2.4_git20230717-r3.apk",
-        "version": "1.2.4_git20230717-r3",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/musl-1.2.4-r2.apk",
+        "version": "1.2.4-r2",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-NNQ75vr/hK4jV2vPfqjHBLXY/TM="
+          "range": "bytes=0-666",
+          "checksum": "sha1-MiA7YiamUyscxmdGiRBGiJjcW8U="
         },
         "control": {
-          "range": "bytes=665-1230",
-          "checksum": "sha1-mG43yRO1rMNfnDquG8JNnxoYTo8="
+          "range": "bytes=667-1224",
+          "checksum": "sha1-odtIYtKyOCg6suF/cDaYpygL7hw="
         },
         "data": {
-          "range": "bytes=1231-667648",
-          "checksum": "sha256-ORxgfIRz5cUD3/rXyYZEjCstaJLVkRenlWO+wP5AjTE="
+          "range": "bytes=1225-634880",
+          "checksum": "sha256-KPwSgRdeAcnVvczowX1F54Aszov9ZI1cRXgtFZzepfg="
         }
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/busybox-1.36.1-r13.apk",
-        "version": "1.36.1-r13",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-oH8hu95JyOShO0oPRBI3ZPlsc8c="
+          "checksum": "sha1-oXF25kDE6Jja1iQ2psyt9nV+ddE="
         },
         "control": {
-          "range": "bytes=666-2298",
-          "checksum": "sha1-sjQ/UUfq8kIct0jBd/Kn9xTGfrk="
+          "range": "bytes=666-2301",
+          "checksum": "sha1-aBWv1Kn2ASOLShUeDPoSLaozuMs="
         },
         "data": {
-          "range": "bytes=2299-946176",
-          "checksum": "sha256-1+CUivTOQwYueQba2+pigHUw2TwBErH4xehbc2TYkFQ="
+          "range": "bytes=2302-946176",
+          "checksum": "sha256-pDdzepugl8LYISmpJ2wGr885gfpwo2hi9ZMf4dQTi5s="
         }
       },
       {
         "name": "busybox-binsh",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/busybox-binsh-1.36.1-r13.apk",
-        "version": "1.36.1-r13",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-binsh-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-2toLRvkAYYW0nHTvpkCgnn3g3RY="
+          "range": "bytes=0-664",
+          "checksum": "sha1-IAXZAY5sZRBoY7kkoTAdfMP0PQk="
         },
         "control": {
-          "range": "bytes=664-1255",
-          "checksum": "sha1-Vkioe80JJvptFluk573ab7S3P8Q="
+          "range": "bytes=665-1253",
+          "checksum": "sha1-5fBkcCHhCSy+P6TPSptuqyKrf0Y="
         },
         "data": {
-          "range": "bytes=1256-8192",
-          "checksum": "sha256-OdEj4Ao2RdXwZpU3qUZ8h8e8k0e1B5uf/zQG1Bc0/sY="
+          "range": "bytes=1254-8192",
+          "checksum": "sha256-tzuIHJhe4F+8yHDjxg5teCjcUNiOs0LUJrjvDKhxWYo="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libcrypto3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libcrypto3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-RpBcK7xat0wA+KU8v90ik+02GY0="
+          "range": "bytes=0-666",
+          "checksum": "sha1-rsFFJCNY9v5Y5nk+ilFNshjU5ZM="
         },
         "control": {
-          "range": "bytes=664-1237",
-          "checksum": "sha1-fTSwhJ608ezS+2hNlCw58K2EVGU="
+          "range": "bytes=667-1242",
+          "checksum": "sha1-o+vFJMnZukduV7Y+lgb7DvYwlJo="
         },
         "data": {
-          "range": "bytes=1238-4608000",
-          "checksum": "sha256-fxWyvpB5v16oFvviR3jfT1p1ncqzJhpxSaDNZsUG3tQ="
+          "range": "bytes=1243-4579328",
+          "checksum": "sha256-ShDVFFbFbOMefQmaq1tSTTFvC/jHov5k8X5zcCsDSck="
         }
       },
       {
         "name": "ca-certificates",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/ca-certificates-20230506-r0.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/ca-certificates-20230506-r0.apk",
         "version": "20230506-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-666",
-          "checksum": "sha1-MnzTkHZE1VZCbJ0+yO/fr7VjD8g="
+          "range": "bytes=0-665",
+          "checksum": "sha1-5UkuWVygPgpCoaxEzz8EXPtDMEw="
         },
         "control": {
-          "range": "bytes=667-1574",
-          "checksum": "sha1-+uveAQeeWLy7IxxTdy5KAAutdQw="
+          "range": "bytes=666-1574",
+          "checksum": "sha1-FG8M+7w+dkjV9Vy0mGFWW2t4+Do="
         },
         "data": {
           "range": "bytes=1575-704512",
-          "checksum": "sha256-ctYgZXWrTc4HQ/rjb1M1k2GYfO5/L8AQro55dEYuk4o="
+          "checksum": "sha256-BJOYfHwliYN95TgrERMUHssqnNtWVji64rk6oBHf+wc="
         }
       },
       {
         "name": "libmagic",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libmagic-5.45-r1.apk",
-        "version": "5.45-r1",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libmagic-5.45-r0.apk",
+        "version": "5.45-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-662",
-          "checksum": "sha1-Y7E7cCRHTUITWjx73VdXfTuUdgQ="
+          "checksum": "sha1-D902pQuhrqfT1bzsF26f2mTpyh8="
         },
         "control": {
-          "range": "bytes=663-1241",
-          "checksum": "sha1-34ALZ/Y+f6juXy//QDqh/MEeylA="
+          "range": "bytes=663-1237",
+          "checksum": "sha1-SjvMy9oUFh4KOoc+rqi07rW1AnI="
         },
         "data": {
-          "range": "bytes=1242-8667136",
-          "checksum": "sha256-7UOEqpfwvq9Rgx5GMP3Xslf4FH8mu0qsqLxDTZ8Zz+w="
+          "range": "bytes=1238-8671232",
+          "checksum": "sha256-VJGV3hiByOlRHboPar7fsGn2Dk3FemioGnUd2blb1Dw="
         }
       },
       {
         "name": "file",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/file-5.45-r1.apk",
-        "version": "5.45-r1",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/file-5.45-r0.apk",
+        "version": "5.45-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-TgFrwxRX5L4y9S+OEUz1aVFB90w="
+          "range": "bytes=0-664",
+          "checksum": "sha1-Fi5n6rRACMW+hIMcKvgimHrGizo="
         },
         "control": {
-          "range": "bytes=664-1240",
-          "checksum": "sha1-1+TftWmPKud22iOxtUHJPGKbkwA="
+          "range": "bytes=665-1238",
+          "checksum": "sha1-SEFJtQBwBLWxAvEm3Xgti3EmDOg="
         },
         "data": {
-          "range": "bytes=1241-45056",
-          "checksum": "sha256-S+suzhR/v9Gx+j0smILUOtQByHiuPkQ3fEXXGGCGP6s="
+          "range": "bytes=1239-36864",
+          "checksum": "sha256-Ui5uuh3uI2DTgGhqpK/p+a7eHtnYTJrLC4NNp5R0RnU="
         }
       },
       {
         "name": "bzip2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/bzip2-1.0.8-r6.apk",
-        "version": "1.0.8-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/bzip2-1.0.8-r5.apk",
+        "version": "1.0.8-r5",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-P67oLjpMRJNMrayXx4q2Gl+76Ng="
+          "range": "bytes=0-665",
+          "checksum": "sha1-hd6Yb9FZIB+f8Z1VeEq3luZKyVg="
         },
         "control": {
-          "range": "bytes=664-1277",
-          "checksum": "sha1-KKvV9vd5o4u2wVOlyo1Fzut2BxI="
+          "range": "bytes=666-1284",
+          "checksum": "sha1-QuU9Hyb+/gRybwZGGTFWeAAGNtc="
         },
         "data": {
-          "range": "bytes=1278-339968",
-          "checksum": "sha256-cHfSeV/APP7lcD9JZOgqDMlIbBhmLCm52H22WvhsMig="
+          "range": "bytes=1285-339968",
+          "checksum": "sha256-mzqFLovP+R3VWlz+k/cmmFoSRp9+t3jLeaxYhAerMdc="
         }
       },
       {
         "name": "libbz2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libbz2-1.0.8-r6.apk",
-        "version": "1.0.8-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libbz2-1.0.8-r5.apk",
+        "version": "1.0.8-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-hpnPXaGPm2DMu4/WvuiMSybIXEM="
+          "checksum": "sha1-SrnmCKTBlo4NV4KFDtDWdnXNHyE="
         },
         "control": {
-          "range": "bytes=666-1223",
-          "checksum": "sha1-qyKCdp/o4nO8dx8icoZMk9bJDc0="
+          "range": "bytes=666-1228",
+          "checksum": "sha1-v13gWmLEhB4wJ6i0S77ZTIkSSDU="
         },
         "data": {
-          "range": "bytes=1224-90112",
-          "checksum": "sha256-Mk9dHzeS6VvIVwmzD3d+qNJ2V98H+RnPYF31Ber329Y="
+          "range": "bytes=1229-90112",
+          "checksum": "sha256-9gtKlIWJkJcLFewUkd8DNNGyYkbOs5De6Ulac22H3yQ="
         }
       },
       {
         "name": "libcap2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libcap2-2.69-r1.apk",
-        "version": "2.69-r1",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libcap2-2.69-r0.apk",
+        "version": "2.69-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-Bd6Tqdb8bdPbmO0bR3C/XKxLOxU="
+          "range": "bytes=0-665",
+          "checksum": "sha1-6/vQH9Ng3YCoc+qScJhwxOFNwaA="
         },
         "control": {
-          "range": "bytes=665-1280",
-          "checksum": "sha1-cywvJAUrMCU2omdoUqGqtfH+5mQ="
+          "range": "bytes=666-1280",
+          "checksum": "sha1-x2rIM8+ePWI5y9o1VKMEaJR0M7E="
         },
         "data": {
           "range": "bytes=1281-73728",
-          "checksum": "sha256-C4aJqzuMt6c6rvl0yMyOqKs4nVfl4ZTqpp80ugkpOt4="
+          "checksum": "sha256-TL/HrBgJfC5Cxe0UvxvwRZ8ujCl1SzDe9hYwSGZsf3Y="
         }
       },
       {
         "name": "zlib",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/zlib-1.3-r0.apk",
-        "version": "1.3-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/zlib-1.2.13-r1.apk",
+        "version": "1.2.13-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-mAWk+xBjBT417iizUU/qsJFibcg="
+          "checksum": "sha1-RZ/XtPM+9VTzGKPTkXeD5oDXIcs="
         },
         "control": {
-          "range": "bytes=666-1214",
-          "checksum": "sha1-UyU/FOShjX2c7vV6LrJJqHoEww4="
+          "range": "bytes=666-1220",
+          "checksum": "sha1-JlboSJkrN4qkDcokr4zenpcWEXQ="
         },
         "data": {
-          "range": "bytes=1215-110592",
-          "checksum": "sha256-F/PCJowznw2vgmZQGOtIYEZ6N0FSXQhGcm9YOFfuUQw="
+          "range": "bytes=1221-110592",
+          "checksum": "sha256-HnBSZY+OVxwRCfdw6m7xWuud/H5ID/imx2OeK/2VRbI="
         }
       },
       {
         "name": "cdrkit",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/cdrkit-1.1.11-r6.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/cdrkit-1.1.11-r6.apk",
         "version": "1.1.11-r6",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-PcaIcvtCYH3YmMKt9HnGV2S+4+Y="
+          "range": "bytes=0-662",
+          "checksum": "sha1-Rhda2VbKq6eni4xEmUo0TTc/dFA="
         },
         "control": {
-          "range": "bytes=666-1411",
-          "checksum": "sha1-DxC8qRwPAlKzaSvOjYQWRpNIekg="
+          "range": "bytes=663-1410",
+          "checksum": "sha1-6wXMBtteLPgKegPqCoPiK+P1UXE="
         },
         "data": {
-          "range": "bytes=1412-2392064",
-          "checksum": "sha256-jqEOsCHVJ3Y9igFdkTKFvuLtuhej/hv8oKzOBH1WoR4="
+          "range": "bytes=1411-2392064",
+          "checksum": "sha256-+qs75bsJ2kQVN90xiZPQze7FQ6sQEvCcZl60nlMnOiU="
         }
       },
       {
         "name": "brotli-libs",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/brotli-libs-1.1.0-r0.apk",
-        "version": "1.1.0-r0",
-        "architecture": "x86_64",
-        "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-xkZx1U9mp+9Ik4nietlj1ThaP4g="
-        },
-        "control": {
-          "range": "bytes=665-1250",
-          "checksum": "sha1-5/axWS+KrIPs9/zhuY0x4jbZmmc="
-        },
-        "data": {
-          "range": "bytes=1251-954368",
-          "checksum": "sha256-6sAVXlveeTYOdp5NzMSQwcfgf1w92155wDMX7wWdf/I="
-        }
-      },
-      {
-        "name": "c-ares",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/c-ares-1.20.1-r0.apk",
-        "version": "1.20.1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/brotli-libs-1.0.9-r14.apk",
+        "version": "1.0.9-r14",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-F8LGtQvQIi3VKhNl5e93rKACS/M="
+          "checksum": "sha1-CeOPY3qLHS7zl3Fcdv8Q+X1ovso="
         },
         "control": {
-          "range": "bytes=666-1227",
-          "checksum": "sha1-N9wCu9wwKDeB2wkQl+0F0tSScIg="
+          "range": "bytes=666-1257",
+          "checksum": "sha1-SLIAbTXN3oSaGPfK2/rxfJJzEw8="
         },
         "data": {
-          "range": "bytes=1228-106496",
-          "checksum": "sha256-CRD7nux09DUxzCCIpuOcMzPkwesZKtikXXwXOmnQHuI="
+          "range": "bytes=1258-806912",
+          "checksum": "sha256-5pVZ5oqwBX/LmefVFD1i5Lsusi7LQfVR5EdCRzJmcyo="
         }
       },
       {
         "name": "libunistring",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libunistring-1.1-r2.apk",
-        "version": "1.1-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libunistring-1.1-r1.apk",
+        "version": "1.1-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-cTUIglMFCL+O8Sb/UkXmYpobuJI="
+          "range": "bytes=0-665",
+          "checksum": "sha1-Qv1EqFQdXRldGbtgk7ywgj2yRxU="
         },
         "control": {
-          "range": "bytes=665-1262",
-          "checksum": "sha1-YbcBtv9bd3AK9R2s7uqTLAvH0CY="
+          "range": "bytes=666-1270",
+          "checksum": "sha1-FM6LSxIv3TOssRzH8QaqBWHCGaE="
         },
         "data": {
-          "range": "bytes=1263-1708032",
-          "checksum": "sha256-4FbUuvCuMqNXarZ5XcrSYTtqgm0t8zOBgakMR3lXq4E="
+          "range": "bytes=1271-1736704",
+          "checksum": "sha256-o6NDJkUwWe/UhpOfjUmBQWAod0+e8RsirOiMZt1AMog="
         }
       },
       {
         "name": "libidn2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libidn2-2.3.4-r4.apk",
-        "version": "2.3.4-r4",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libidn2-2.3.4-r1.apk",
+        "version": "2.3.4-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-sralOXk1Hd0O1ByUYQk4VM3HrWs="
+          "checksum": "sha1-jX3ZRVnGxGpPF2TYkYAQQ+KM6Zo="
         },
         "control": {
-          "range": "bytes=666-1280",
-          "checksum": "sha1-dquGXF1eiNQStvQWvGoNcFguZ50="
+          "range": "bytes=666-1289",
+          "checksum": "sha1-e8PNgko4hneETI5udcz1NEz0L28="
         },
         "data": {
-          "range": "bytes=1281-212992",
-          "checksum": "sha256-n0xMTorhbuzFattyq/XF3twqMVx/aCtWEFWxacjhvYk="
+          "range": "bytes=1290-212992",
+          "checksum": "sha256-lu4ypIr4dfDtPCf9oT3aQxHGI/4RBwt2T0+pTeipNBU="
         }
       },
       {
         "name": "nghttp2-libs",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/nghttp2-libs-1.57.0-r0.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/nghttp2-libs-1.57.0-r0.apk",
         "version": "1.57.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-PZ4yKzLl9VOtZ0sSkJc7pabH2G4="
+          "range": "bytes=0-664",
+          "checksum": "sha1-IpoSOAbCsaNmwWX+CPRLtNCXwtk="
         },
         "control": {
-          "range": "bytes=664-1237",
-          "checksum": "sha1-LCzQQfrTjQ99TsdwPuI2AsGRy3I="
+          "range": "bytes=665-1250",
+          "checksum": "sha1-S9cOYKpPfZ6/ZrJHJctl/7/04NM="
         },
         "data": {
-          "range": "bytes=1238-155648",
-          "checksum": "sha256-For6nIxTAusv1Pn2TsR3//9hJ0JwvXN6YyHcUoFOLqE="
+          "range": "bytes=1251-155648",
+          "checksum": "sha256-EmIwhou+sAkPN7ksoxMwwan7+nHzBTgzZaf5bO0A5PA="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libssl3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libssl3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-Gw1ROMOxR2FzfK0VGBLyRN5vFnI="
+          "range": "bytes=0-666",
+          "checksum": "sha1-jSfScM7agyOdR/4YaEfwxAwU/og="
         },
         "control": {
-          "range": "bytes=665-1241",
-          "checksum": "sha1-IUlQPgV72PUNlzwYG9cJvQjH7OY="
+          "range": "bytes=667-1244",
+          "checksum": "sha1-o47c8bt1FJzVuhEX26C7/lIsPmY="
         },
         "data": {
-          "range": "bytes=1242-561152",
-          "checksum": "sha256-BHjMuoOyQGPhBt81Ecom5eMYVa2oQJGnxk2kuTekszk="
+          "range": "bytes=1245-565248",
+          "checksum": "sha256-qldSVOcIZhLSJwERlZZI3OVkNzByKPUYalxsXALI7tk="
         }
       },
       {
         "name": "libcurl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libcurl-8.4.0-r0.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libcurl-8.4.0-r0.apk",
         "version": "8.4.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-qVWjqT4UDWQgpJswJIGdw+f22BQ="
+          "range": "bytes=0-663",
+          "checksum": "sha1-Q1/zQGYYbFfpHfx4oYYF6jzv/5g="
         },
         "control": {
-          "range": "bytes=665-1280",
-          "checksum": "sha1-xzBZW907iXKPtl9S5WFdIl2oaAA="
+          "range": "bytes=664-1271",
+          "checksum": "sha1-xBpvkAuwlXJ/cG7VPdUv809YbMg="
         },
         "data": {
-          "range": "bytes=1281-589824",
-          "checksum": "sha256-4l9HadGUGn8NcoUG2sF2TuBbvFJs+rGamESnXjnwO9M="
+          "range": "bytes=1272-598016",
+          "checksum": "sha256-NkUn30Hnf3TlPLsjEcOOcKm/QAd5EaYSLxEx3ENtix0="
         }
       },
       {
         "name": "ssl_client",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/ssl_client-1.36.1-r13.apk",
-        "version": "1.36.1-r13",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/ssl_client-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-D731JOIZIHcSI+CsOb2FvRpHB0c="
+          "range": "bytes=0-662",
+          "checksum": "sha1-WoBA8G9WUPUjqwQF0uXPpTZ8RgM="
         },
         "control": {
-          "range": "bytes=666-1295",
-          "checksum": "sha1-a/3ESLqRCoHfKMKRQGy46qaZfIM="
+          "range": "bytes=663-1293",
+          "checksum": "sha1-2KNylQ9b6XW3cN6rwXzZu80Gcho="
         },
         "data": {
-          "range": "bytes=1296-28672",
-          "checksum": "sha256-UXRcPjAC9tfvXPDWoB5bTGtcahxGJiDV2Omd9PZb2gc="
+          "range": "bytes=1294-28672",
+          "checksum": "sha256-1QBipexmn7zgllOXDb8FOMjCfZy3TsZ+pVK1qrL1cQ0="
         }
       },
       {
         "name": "curl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/curl-8.4.0-r0.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/curl-8.4.0-r0.apk",
         "version": "8.4.0-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-664",
-          "checksum": "sha1-N3N6Eju3uiTPkjSlGwxZWnvp4gk="
+          "checksum": "sha1-lu7pVWiIVlqyle+tLYZVaay/k/Y="
         },
         "control": {
-          "range": "bytes=665-1231",
-          "checksum": "sha1-gfeY6jHNuji8wPh9ASfD5K3JMVw="
+          "range": "bytes=665-1229",
+          "checksum": "sha1-dniSzRZDzQc9a6aEa380UuOFG3s="
         },
         "data": {
-          "range": "bytes=1232-253952",
-          "checksum": "sha256-C3Prft1rTW8tsa9ysQqB/zapBgwS6CJIsmommQd7giQ="
+          "range": "bytes=1230-253952",
+          "checksum": "sha256-GSEimu+Su3k/4xYITuxSUO/+F5F/uNfkUWhe6+z7h5U="
         }
       },
       {
         "name": "libmnl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libmnl-1.0.5-r2.apk",
-        "version": "1.0.5-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libmnl-1.0.5-r1.apk",
+        "version": "1.0.5-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-660",
-          "checksum": "sha1-yyDMDrbQQf73c2P7FJJRfsyqFOY="
+          "range": "bytes=0-665",
+          "checksum": "sha1-NbvjuHYenjEgirW9hWi5IRusZ9A="
         },
         "control": {
-          "range": "bytes=661-1241",
-          "checksum": "sha1-NqDyLUl7k8ND7qAmQORX5Vax9/o="
+          "range": "bytes=666-1252",
+          "checksum": "sha1-i06QucxuCP7iMSS2xUWUg5pl380="
         },
         "data": {
-          "range": "bytes=1242-40960",
-          "checksum": "sha256-6rtbXFvHI+XH/8TwzrIK8Fp8bjV1XGcXAWx9L8x/MYQ="
+          "range": "bytes=1253-40960",
+          "checksum": "sha256-Hrg2Tbo1zK96mc7RssKo3fkjZZiG12TuOF08f2qSCbs="
         }
       },
       {
         "name": "ethtool",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/ethtool-6.5-r0.apk",
-        "version": "6.5-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/ethtool-6.2-r1.apk",
+        "version": "6.2-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-666",
-          "checksum": "sha1-EdSWPeOJ/wO6vOBs3gv/UiQ4j5c="
+          "range": "bytes=0-664",
+          "checksum": "sha1-IzJ2bL6CSE9SBkFi7cXgPPKjszo="
         },
         "control": {
-          "range": "bytes=667-1273",
-          "checksum": "sha1-Yz4XOjG5+USp6dNjzSw2xCGPQsk="
+          "range": "bytes=665-1273",
+          "checksum": "sha1-GQ4QdsfQ/1g7JfOgZ11mkQnmEn4="
         },
         "data": {
-          "range": "bytes=1274-503808",
-          "checksum": "sha256-WGc6rr4tRvbYwaGVY5KNrwtBVKsCjs5wU+MJ65AqnWw="
+          "range": "bytes=1274-483328",
+          "checksum": "sha256-BfEh76bHGiBOtfmzYlnOxCpgDjcULTAdce9RrZCab9E="
         }
       },
       {
         "name": "libexpat",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libexpat-2.5.0-r2.apk",
-        "version": "2.5.0-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libexpat-2.5.0-r1.apk",
+        "version": "2.5.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-666",
-          "checksum": "sha1-n0vE4cXGVEQGpFLaUlEFjlBnCSs="
+          "range": "bytes=0-664",
+          "checksum": "sha1-I/AuLvf+7f1FAaV4bDXTwbk3gL4="
         },
         "control": {
-          "range": "bytes=667-1240",
-          "checksum": "sha1-mv0QW0qdKn/lCvZPl+Lyejzj8Ys="
+          "range": "bytes=665-1243",
+          "checksum": "sha1-HckygN+FaPOKMnPm/G6nsK7Ddvw="
         },
         "data": {
-          "range": "bytes=1241-147456",
-          "checksum": "sha256-kyAkJF2AM8lWKLepjlR6wk5ZffbnvaHJrJ3c7ftKIWQ="
+          "range": "bytes=1244-147456",
+          "checksum": "sha256-6lKauUDr94a0KaSKZt6bbMFil9Z3SBrv/xcxrWpaLJg="
         }
       },
       {
         "name": "pcre2",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/pcre2-10.42-r1.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/pcre2-10.42-r1.apk",
         "version": "10.42-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-JPBjkbakBHdpVpiF8PuHm038g3k="
+          "range": "bytes=0-665",
+          "checksum": "sha1-y16ZhdSzFPue5B/d7fHMEMM9VlA="
         },
         "control": {
-          "range": "bytes=665-1253",
-          "checksum": "sha1-u6HRcxbnXAb9OtuAPHz/Tcbqhxw="
+          "range": "bytes=666-1253",
+          "checksum": "sha1-GVvOXp8moLoU9GDN9SGWx+OH8oI="
         },
         "data": {
           "range": "bytes=1254-692224",
-          "checksum": "sha256-N21s1SOI2yTaxFUQkaOwUIpRvr03PDT+hWRN7SH/O8Y="
+          "checksum": "sha256-KiRNeBlKLiMK9hJ7JNMzHOEo7zFO/x9uAGwxh64ObaM="
         }
       },
       {
         "name": "git",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/git-2.42.0-r0.apk",
-        "version": "2.42.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/git-2.40.1-r0.apk",
+        "version": "2.40.1-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-Ad724GJC9yRzPjq10fnJw6YNJRw="
+          "range": "bytes=0-666",
+          "checksum": "sha1-VvozQSm9a1zWR+cPAxBOetPM5Jk="
         },
         "control": {
-          "range": "bytes=664-1283",
-          "checksum": "sha1-Cw1rO00H+nfeFTR1kH4N6Q5HC28="
+          "range": "bytes=667-1291",
+          "checksum": "sha1-zLlRzliw0tRhZDTrLXnMgdtg0OI="
         },
         "data": {
-          "range": "bytes=1284-6164480",
-          "checksum": "sha256-j98bf9+iEtgvZ+jGqB+QPKwQCUFkz2O6ICAIgY3awx4="
+          "range": "bytes=1292-6090752",
+          "checksum": "sha256-tzr8hlsJmZ1xXtNdvFMfEX4NMj0DTKa2f/Edyr02xyQ="
         }
       },
       {
         "name": "oniguruma",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/oniguruma-6.9.9-r0.apk",
-        "version": "6.9.9-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/oniguruma-6.9.8-r1.apk",
+        "version": "6.9.8-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-Br6vG5+FyMj5WveM8HPXFpRdwro="
+          "range": "bytes=0-667",
+          "checksum": "sha1-myjYxh6kThj5ZY78culUlvZpE84="
         },
         "control": {
-          "range": "bytes=666-1240",
-          "checksum": "sha1-MNBoZs5u0pn7pkF9+0SjdtugGfA="
+          "range": "bytes=668-1247",
+          "checksum": "sha1-HdPCGmiNEhWxPS5qV0nZZLJHaKk="
         },
         "data": {
-          "range": "bytes=1241-565248",
-          "checksum": "sha256-hfPOAmNr3n5xpLZztR+7EMCQzSIU6wbQfIjd2i0cQ6U="
+          "range": "bytes=1248-557056",
+          "checksum": "sha256-rv613enbaRXFkXe5RbgdH0V+H29PXN7eHl7WUDG/N9k="
         }
       },
       {
         "name": "jq",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/jq-1.7-r2.apk",
-        "version": "1.7-r2",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/jq-1.6-r3.apk",
+        "version": "1.6-r3",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-666",
-          "checksum": "sha1-2OCqfux+WEUIJAJ7P69vSimhnG4="
+          "range": "bytes=0-663",
+          "checksum": "sha1-tPzFzR0wFiPQg7XcnQiGy/YeeFg="
         },
         "control": {
-          "range": "bytes=667-1263",
-          "checksum": "sha1-E5tb1oF7r3CoAG8j4pgOTF35IYE="
+          "range": "bytes=664-1277",
+          "checksum": "sha1-a+tNKTUC2Ed/MMtRWWOXvc3f2F8="
         },
         "data": {
-          "range": "bytes=1264-651264",
-          "checksum": "sha256-6+s+9qOObP3uwz1Rdj5tPUqhvoNam+nz5r+dWcqAFP4="
+          "range": "bytes=1278-557056",
+          "checksum": "sha256-K0xZfugjpGym0YtX1lJKmgFRqEw1mlw3lvXr1MdN3zA="
         }
       },
       {
         "name": "ncurses-terminfo-base",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/ncurses-terminfo-base-6.4_p20231007-r0.apk",
-        "version": "6.4_p20231007-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/ncurses-terminfo-base-6.4_p20230506-r0.apk",
+        "version": "6.4_p20230506-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-dQWCBcvJS83/i9prv1/96pqRMXc="
+          "range": "bytes=0-666",
+          "checksum": "sha1-WIklBDT5GyI49edKUhhxQbw8Gvg="
         },
         "control": {
-          "range": "bytes=664-1201",
-          "checksum": "sha1-FwSNsTx5fkSvlQ9qUtjqpGXspHg="
+          "range": "bytes=667-1210",
+          "checksum": "sha1-0a6n6U74hqvF5n9KAe2AjnhuN9g="
         },
         "data": {
-          "range": "bytes=1202-217088",
-          "checksum": "sha256-4RQPkPAZ6CO2GgzATrTHHGrjRdVv6aFQaX7w8xo/0Yo="
+          "range": "bytes=1211-221184",
+          "checksum": "sha256-zE4CVCH+49hBwX9dWYrNo3LoPWNP9ZnTBR4lfBHmgdE="
         }
       },
       {
         "name": "libncursesw",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libncursesw-6.4_p20231007-r0.apk",
-        "version": "6.4_p20231007-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libncursesw-6.4_p20230506-r0.apk",
+        "version": "6.4_p20230506-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-CXM9n8LDzUXaGJwGjcTCW+fpmQY="
+          "range": "bytes=0-665",
+          "checksum": "sha1-U9jndUo5GJq6tbLUjsBQJVEEArE="
         },
         "control": {
-          "range": "bytes=665-1256",
-          "checksum": "sha1-q903+COHj8GJxyLXDfkqt5XtdeY="
+          "range": "bytes=666-1265",
+          "checksum": "sha1-dD0p75kd/SeiqiNdbcrVT0ZTiOY="
         },
         "data": {
-          "range": "bytes=1257-352256",
-          "checksum": "sha256-HDOTAOrL1wUCLm/df64Placsl2XFMhGZYueKswCkSwQ="
+          "range": "bytes=1266-352256",
+          "checksum": "sha256-pGJFboqQXYNh5mFLz2vUhHhfunqniyS3nlmv3pkji8s="
         }
       },
       {
         "name": "less",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/less-643-r1.apk",
-        "version": "643-r1",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/less-633-r0.apk",
+        "version": "633-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-gTD+TVbyXlns3FsrNgF5XMq6YlI="
+          "range": "bytes=0-667",
+          "checksum": "sha1-i58f71Q1b471iGzWnf5k2WH1RBk="
         },
         "control": {
-          "range": "bytes=666-1267",
-          "checksum": "sha1-jUg3NsV97MAsWb2j6QRK1ogaIHE="
+          "range": "bytes=668-1272",
+          "checksum": "sha1-xZoAzBM7IkCJ1cHPYRhjGqH2DX4="
         },
         "data": {
-          "range": "bytes=1268-221184",
-          "checksum": "sha256-qMbeDoc+JeeNNaEc96YWuJ9Hh8eiipuPDhZVzXtR95A="
+          "range": "bytes=1273-221184",
+          "checksum": "sha256-YmmXEQM1Ay/hGW3AMu0wL8+KoRd7V7PZzzV5f8HdSpE="
         }
       },
       {
-        "name": "musl-obstack",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/musl-obstack-1.2.3-r2.apk",
-        "version": "1.2.3-r2",
-        "architecture": "x86_64",
-        "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-ZZinq9Kt5A7btL70WNINlOyMdwk="
-        },
-        "control": {
-          "range": "bytes=665-1259",
-          "checksum": "sha1-3bhmn6hmA9pXwDrXNpExU4LJL6A="
-        },
-        "data": {
-          "range": "bytes=1260-28672",
-          "checksum": "sha256-l0WOI/SyZ4smtSOMRP6HCOC9M8Hr7XGV9VfaukS1NrQ="
-        }
-      },
-      {
-        "name": "libucontext",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libucontext-1.2-r2.apk",
-        "version": "1.2-r2",
-        "architecture": "x86_64",
-        "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-EQqWvel6ikS+p2JBc+M3QCIQcmE="
-        },
-        "control": {
-          "range": "bytes=665-1245",
-          "checksum": "sha1-KGSOy6LYcu0n9RQPDEouNJZTUDU="
-        },
-        "data": {
-          "range": "bytes=1246-40960",
-          "checksum": "sha256-2q5eSSJawHBfn89LrRkEGLVgdyA25SryCUYcUL2G9Mg="
-        }
-      },
-      {
-        "name": "gcompat",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/gcompat-1.1.0-r4.apk",
-        "version": "1.1.0-r4",
+        "name": "libc6-compat",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libc6-compat-1.2.4-r2.apk",
+        "version": "1.2.4-r2",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-666",
-          "checksum": "sha1-voGpgzIcZD2nuJgWihRThavv9JM="
+          "checksum": "sha1-J+LbsvPidjBEjGFkHV6+vJPTymg="
         },
         "control": {
-          "range": "bytes=667-1289",
-          "checksum": "sha1-F+WycXm/+x7Bo0p727l8EyFMfIY="
+          "range": "bytes=667-1209",
+          "checksum": "sha1-16wHrDOlMuA9FcrNOOyBp8j8sWQ="
         },
         "data": {
-          "range": "bytes=1290-106496",
-          "checksum": "sha256-E3YVZobU2LhlnSwZL3JzOyEhI4Xl8/+N7yScR2kZ1bs="
+          "range": "bytes=1210-12288",
+          "checksum": "sha256-Z1xJqbx6H833/BsAmC4Ncu9YPFFoc/TX5EMA/GNzIBY="
         }
       },
       {
         "name": "openssh-keygen",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/openssh-keygen-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/openssh-keygen-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-666",
-          "checksum": "sha1-RqGMT8CQTJ053yiFqqeHAS5bYeA="
+          "range": "bytes=0-662",
+          "checksum": "sha1-7yWoAVDFHZ7wkaK1x31xfRl3sh0="
         },
         "control": {
-          "range": "bytes=667-1269",
-          "checksum": "sha1-0c+RzZ8CGFUbCxJVNm15+uINvbk="
+          "range": "bytes=663-1262",
+          "checksum": "sha1-8HKD+gemWeNLp/t5rGmx94P+gLY="
         },
         "data": {
-          "range": "bytes=1270-569344",
-          "checksum": "sha256-uTy/xS70XaWGD9W6qUs56YwYts/0D/BMB0yPohzGk6c="
+          "range": "bytes=1263-569344",
+          "checksum": "sha256-5+LvDfDZYB/LW2uWml3QsryCnW963y03Ws+PP+yvCLw="
         }
       },
       {
         "name": "libedit",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libedit-20230828.3.1-r3.apk",
-        "version": "20230828.3.1-r3",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libedit-20221030.3.1-r1.apk",
+        "version": "20221030.3.1-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-8dF+8Jwir24o2+uShKak3egU28o="
+          "range": "bytes=0-665",
+          "checksum": "sha1-uf1pfUhd4xT9OU9FwW8Nxa3oyW4="
         },
         "control": {
-          "range": "bytes=664-1240",
-          "checksum": "sha1-PJw71Y+3fzlgURO0wAusbk9SFe8="
+          "range": "bytes=666-1251",
+          "checksum": "sha1-5PBvyyEwd5KjwG3lTYwXuEw/+Hw="
         },
         "data": {
-          "range": "bytes=1241-192512",
-          "checksum": "sha256-Ig1n9UQoSArFheGsmHT1O12MDroFMWsMsjkopgaT29w="
+          "range": "bytes=1252-196608",
+          "checksum": "sha256-pYvT118csba7eORH+Mk8sdF1/8VgSA6n9v9Z8g+EKNY="
         }
       },
       {
         "name": "openssh-client-common",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/openssh-client-common-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/openssh-client-common-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-666",
-          "checksum": "sha1-G4eYpAZDnEd7K7qyKp3NjqP+1qM="
+          "range": "bytes=0-662",
+          "checksum": "sha1-FvtVqMX5rwafELjQCOWmiySHpSc="
         },
         "control": {
-          "range": "bytes=667-1334",
-          "checksum": "sha1-XrM87HYldos0f2Ny6tEM4zyR+IU="
+          "range": "bytes=663-1325",
+          "checksum": "sha1-JSo11AfT15NbLB0hpXCUlUuD3kY="
         },
         "data": {
-          "range": "bytes=1335-2895872",
-          "checksum": "sha256-GM1CdGgEXEBL+WPGWC1Recn0RAueWeHsdA5PoZdEmm4="
+          "range": "bytes=1326-2871296",
+          "checksum": "sha256-pW5DsI723Mje4/lm9lmfLUzcd0FtROPY3F9/YVEmpRg="
         }
       },
       {
         "name": "openssh-client-default",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/openssh-client-default-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/openssh-client-default-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-ABDW2BpKRcQc45NXKN5gy1a1e7M="
+          "range": "bytes=0-660",
+          "checksum": "sha1-jFsXxLt/6vB9rg52N04VrWRBdKI="
         },
         "control": {
-          "range": "bytes=666-1297",
-          "checksum": "sha1-Jhjv3ZMxHhxK5J9j92hiRLFuU2Q="
+          "range": "bytes=661-1288",
+          "checksum": "sha1-4FaITAH6/oWwVE/G+9Uxymec4z4="
         },
         "data": {
-          "range": "bytes=1298-933888",
-          "checksum": "sha256-IAh4kGgTQSFDzygjkEmQUeb0xctFoTGt2e41LSXxhmM="
+          "range": "bytes=1289-921600",
+          "checksum": "sha256-yXZh7B0DoVfD5jVQtkBmHqpFz8MHnl7TC0tEQyCkrGQ="
         }
       },
       {
         "name": "openssh-sftp-server",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/openssh-sftp-server-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/openssh-sftp-server-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-06xieB2kpt4QqQZ7hgZwnK7ZlyE="
+          "range": "bytes=0-663",
+          "checksum": "sha1-bwds4yqZjdKK1WmAdNO2s4IR0IM="
         },
         "control": {
-          "range": "bytes=665-1222",
-          "checksum": "sha1-1JZ01yQL6RQhqMDuLnOSV7URMHk="
+          "range": "bytes=664-1216",
+          "checksum": "sha1-dmqpX0Wavqwfyq+43N5r1o/poYM="
         },
         "data": {
-          "range": "bytes=1223-184320",
-          "checksum": "sha256-OzN6tSS0u8PWfQQiM8+4OnGBQf9lIPSik/fGKZv12kk="
+          "range": "bytes=1217-184320",
+          "checksum": "sha256-uxvJJKgcIfC9EbkFANamB0yfYcigMDnUofiWqnHxcog="
         }
       },
       {
         "name": "openssh-server-common",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/openssh-server-common-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/openssh-server-common-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-aM3XG/TRucbn9TBkZRsLQbq3khs="
+          "range": "bytes=0-661",
+          "checksum": "sha1-+sz0GdQPL96ucqTEaDxzEj2HxrQ="
         },
         "control": {
-          "range": "bytes=666-1204",
-          "checksum": "sha1-g4Gngb1uZmcOQxhfNqO3mcqelG8="
+          "range": "bytes=662-1200",
+          "checksum": "sha1-CHAO/mDZrnSkfFjO7WyckK20dB4="
         },
         "data": {
-          "range": "bytes=1205-20480",
-          "checksum": "sha256-V2hmB8gCVsiIt8C6wErX3+HYy6qkRN/BZ+38v0uvNC0="
+          "range": "bytes=1201-32768",
+          "checksum": "sha256-+4M2P8Kxoxlt38UuJOI0cMF+3kYTNdfOQFdxkbyorMY="
         }
       },
       {
         "name": "openssh-server",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/openssh-server-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/openssh-server-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-BHVKkFz9VR60FonVZmHk58l5QhQ="
+          "range": "bytes=0-660",
+          "checksum": "sha1-N5+SgYeaq1C7NmbUdNovPSN9+J0="
         },
         "control": {
-          "range": "bytes=666-1261",
-          "checksum": "sha1-kh4sZeQyP5eD/BKb0aEBUnjEdvA="
+          "range": "bytes=661-1255",
+          "checksum": "sha1-bIRg9D8BLZyETSYR4878NZ1Jta4="
         },
         "data": {
-          "range": "bytes=1262-983040",
-          "checksum": "sha256-Ei2oMlA3qL27pkL2jpIhwAaaKU1MfWCbWEbzls2tLik="
+          "range": "bytes=1256-978944",
+          "checksum": "sha256-ueZ463Co5wWF/CWvEzcGTfLi2fGvnJ9aKzPlhwLH+sQ="
         }
       },
       {
         "name": "openssh",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/openssh-9.5_p1-r0.apk",
-        "version": "9.5_p1-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/openssh-9.3_p2-r0.apk",
+        "version": "9.3_p2-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-PKzFfN9Tx+C7hQxJglsajaXHoK0="
+          "range": "bytes=0-662",
+          "checksum": "sha1-g8ZamvasGer6vKKmQ05bfOBJnXs="
         },
         "control": {
-          "range": "bytes=665-1258",
-          "checksum": "sha1-FDTsLASnxJWDZ9V5SAJkMt31Eqw="
+          "range": "bytes=663-1252",
+          "checksum": "sha1-Lwfxw5Oq5LBNXrbMJu3EHW+VQ+k="
         },
         "data": {
-          "range": "bytes=1259-425984",
-          "checksum": "sha256-6H9Y892ovVSfrMSjhdEalVC868HnF3P3J3l4Dz3X5lQ="
+          "range": "bytes=1253-421888",
+          "checksum": "sha256-cRwYMizuK2o8vOatuUpUIpAzufTGsptEM38JsUzChzk="
         }
       },
       {
         "name": "openssl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/openssl-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/openssl-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-v6L1kj9X57cE6UbVv1iizDm7Iho="
+          "range": "bytes=0-664",
+          "checksum": "sha1-rNOg3oyw7mzkuj4e81IDPIf7n7I="
         },
         "control": {
-          "range": "bytes=664-1279",
-          "checksum": "sha1-8uxnMEDrOESWnPvi0Qv22kDLYgU="
+          "range": "bytes=665-1284",
+          "checksum": "sha1-wsJ9/nmFPn590NsOFCkVP0yF8V8="
         },
         "data": {
-          "range": "bytes=1280-749568",
-          "checksum": "sha256-qfEtSfdnVyShY7W4ynXVMXqpCISrzjX6FqJQs1hrySw="
+          "range": "bytes=1285-770048",
+          "checksum": "sha256-9dEWejwR1e8Yl1VdeozbmHbzz23xEfvFgrEKgAbIQNM="
         }
       },
       {
         "name": "unzip",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/unzip-6.0-r14.apk",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/unzip-6.0-r14.apk",
         "version": "6.0-r14",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-nn5gt5HpCjfRUBct0xAA/PITZoQ="
+          "range": "bytes=0-667",
+          "checksum": "sha1-V07D/FeMJ1m9t8JE2xLaklyAHzI="
         },
         "control": {
-          "range": "bytes=665-1267",
-          "checksum": "sha1-HiJ8SNd0LkBvaxF/xXH0MfjjrXY="
+          "range": "bytes=668-1274",
+          "checksum": "sha1-4Qtv1v4MJ49HYKZEj+piDnsiYBE="
         },
         "data": {
-          "range": "bytes=1268-327680",
-          "checksum": "sha256-Pzc+g+JW6jS7akg/ZGrJJy6zTxJzRL9C5M87ZwnU7bk="
+          "range": "bytes=1275-327680",
+          "checksum": "sha256-54CuveQLQLyn2qbLEia3rac67mRuqAinCa6WhfQ5Jgo="
         }
       }
     ]

--- a/examples/multi_arch_and_repo/apko.yaml
+++ b/examples/multi_arch_and_repo/apko.yaml
@@ -1,7 +1,7 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
-    - https://dl-cdn.alpinelinux.org/alpine/edge/community
+    - https://dl-cdn.alpinelinux.org/alpine/v3.18/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.18/community
   packages:
     - ca-certificates
     - libc6-compat

--- a/examples/oci/apko.resolved.json
+++ b/examples/oci/apko.resolved.json
@@ -58,128 +58,128 @@
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-702",
-          "checksum": "sha1-aH8ZN12tAaPnT4Aw/hJuoERJIKA="
+          "range": "bytes=0-700",
+          "checksum": "sha1-bc/LYdjt1YRKBVqFo0OCWrLDsW4="
         },
         "control": {
-          "range": "bytes=703-1082",
-          "checksum": "sha1-8/M0yEAgqQ3jqVOcRGGLBkBgTtc="
+          "range": "bytes=701-1095",
+          "checksum": "sha1-VOuDI6cngPUe0QMmQTSmAsD6cEY="
         },
         "data": {
-          "range": "bytes=1083-265292",
-          "checksum": "sha256-cc1gzWdor8ICfMstalLxu6iiVvwcTC3gFcrQTdEoHr0="
+          "range": "bytes=1096-265291",
+          "checksum": "sha256-kY0/ezJ2DVrUT2X/oRrXuoiUzfGIXtn3E2owX3JckmQ="
         }
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-701",
-          "checksum": "sha1-BtvtMwa73foDRk9FFY8vfOjKlcA="
+          "range": "bytes=0-705",
+          "checksum": "sha1-H6DEtQIVLnNrXc0r+DcUglYx4Q0="
         },
         "control": {
-          "range": "bytes=702-1043",
-          "checksum": "sha1-P4sTiJm/tqHhC3EkyEYv6WIhELg="
+          "range": "bytes=706-1048",
+          "checksum": "sha1-PVoyenqq3cd0c4fNbErXj3Fma/U="
         },
         "data": {
-          "range": "bytes=1044-416968",
-          "checksum": "sha256-0b2RdCPyUbNNAQSIIJUm8f6Tk0IJwqmvFdpbMpLMExo="
+          "range": "bytes=1049-416967",
+          "checksum": "sha256-q5DBf/WP90hZEKQPr6WXvmZHWaXzRRrFdVsToSR/a7g="
         }
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-699",
-          "checksum": "sha1-j2AQEBUim9hUaC/OJprkdj25+uU="
+          "checksum": "sha1-R8Wr6MgRmGcNHhEi+fouU7SuLtQ="
         },
         "control": {
           "range": "bytes=700-1304",
-          "checksum": "sha1-vupFS8FOeEUOyb6COYGFhQdAonk="
+          "checksum": "sha1-CnMimmBZKU82tMyI5H26UMN6l4I="
         },
         "data": {
-          "range": "bytes=1305-5592271",
-          "checksum": "sha256-vrOifwV6UX3fC1CQQbccbTKbsZtZAZQHRD0VOfrNGYU="
+          "range": "bytes=1305-5592270",
+          "checksum": "sha256-+eWbn5IaCaRs8lB21Pzlfeefho7eb4pIDKMW/6fJMxs="
         }
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-qInWK2AkbXyzmXwQrle1XRqvFLg="
+          "range": "bytes=0-700",
+          "checksum": "sha1-4aNhc3nqFpzcC4jHBFZq+ZC+H4E="
         },
         "control": {
-          "range": "bytes=698-1031",
-          "checksum": "sha1-Bm5JSQB4MbwHXrb0sImXRZM4q6Y="
+          "range": "bytes=701-1035",
+          "checksum": "sha1-PitIgJfOQtIhoDJRkc8o4qOyrM4="
         },
         "data": {
-          "range": "bytes=1032-87924",
-          "checksum": "sha256-n0vQFv6ZagoGu3WSZZZeyb+vxsctdWVgelTlrbhE+mA="
+          "range": "bytes=1036-87925",
+          "checksum": "sha256-+Elk6pIvIJRTeKG9t9//cdnaT2BrfE46X5zg3E0mECA="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-l+OV+d9JsTq9z/XnkV+81NoeO8k="
+          "range": "bytes=0-697",
+          "checksum": "sha1-z8f+mPV44TpZDvrelzOmnA1Oym8="
         },
         "control": {
-          "range": "bytes=704-1090",
-          "checksum": "sha1-F56yGwaHrU8muAlvSzUfIjg9MZs="
+          "range": "bytes=698-1084",
+          "checksum": "sha1-oonZppas7CIEQE5ehp4w4CquAJs="
         },
         "data": {
-          "range": "bytes=1091-4821118",
-          "checksum": "sha256-GJjCDboTV3320kbipKmCcJaNVE10GZHfE4gTfPNp8kE="
+          "range": "bytes=1085-4821143",
+          "checksum": "sha256-FRs9dlQQnlEzpPZSy4WtWDliQI/qieTIHVz5YuMwYWI="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-b6CIWM1fcf5AT2Qu0QjJNJ2nPfU="
+          "range": "bytes=0-704",
+          "checksum": "sha1-VoEhGUsS+iEZ5bCjH2neNirBGMk="
         },
         "control": {
-          "range": "bytes=701-1084",
-          "checksum": "sha1-mop3B1o8c/n/+iHMkFV3Sod61zc="
+          "range": "bytes=705-1088",
+          "checksum": "sha1-BIe7kw60ABsKvB763uT33UzRK7M="
         },
         "data": {
-          "range": "bytes=1085-812710",
-          "checksum": "sha256-ddCg2RwL64xSDPoz9O5jcC1AwMVs1VfDAdiMOBVma30="
+          "range": "bytes=1089-812711",
+          "checksum": "sha256-8P0POxdIJFw75ojZAq/WxeM8h5bWQu0bWX4E8ESpvlc="
         }
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3-r1.apk",
-        "version": "1.3-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3-r2.apk",
+        "version": "1.3-r2",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-BE9hw48pQ/4tg+RyoN+z0KP0sko="
+          "range": "bytes=0-700",
+          "checksum": "sha1-1S276hPYl+9ssemIoJG7TYGfAMM="
         },
         "control": {
-          "range": "bytes=700-1097",
-          "checksum": "sha1-tN0HwtJtpOkMRrRk2w1rfM2mE3Y="
+          "range": "bytes=701-1095",
+          "checksum": "sha1-WYRIXWM96qWE1c0WhV4TM+qSTko="
         },
         "data": {
-          "range": "bytes=1098-191294",
-          "checksum": "sha256-Xzfhp8cXnqEo8ywHmOf2KzBX9JLNU27d2LNZ9MA20pU="
+          "range": "bytes=1096-191254",
+          "checksum": "sha256-i4AaBbeXFdD3FXVsbKC6T9SmUXIrDGkn/wbj+9PX8Lo="
         }
       },
       {
@@ -310,128 +310,128 @@
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-702",
-          "checksum": "sha1-oAK7/0OTHBqjV/x0qqWORgyzoLU="
+          "checksum": "sha1-Twc8OsnLpiLGr1glsxwizLwFm6w="
         },
         "control": {
-          "range": "bytes=703-1086",
-          "checksum": "sha1-iWbLQvCYR2Y6zYJrlKokB14B8hk="
+          "range": "bytes=703-1098",
+          "checksum": "sha1-yRtxTKuHnEGufUD0mlqieHDebDQ="
         },
         "data": {
-          "range": "bytes=1087-266151",
-          "checksum": "sha256-1CNocW3KOzKCJK5++DeAGStj2EAKsnyxIDEDBRRLUDk="
+          "range": "bytes=1099-266150",
+          "checksum": "sha256-6iPIpa/6dq+RZoFex1CmoSSaI6mEN6d8cv4l0YfqiC8="
         }
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-704",
-          "checksum": "sha1-XGqaE5/cq6rT85KSaVpHqmBeW4o="
+          "range": "bytes=0-699",
+          "checksum": "sha1-ySFnkUiQl1nB8rfphClg+mWZCSk="
         },
         "control": {
-          "range": "bytes=705-1049",
-          "checksum": "sha1-vY6oBBxN635Sy2L6y/wgvjpBeh0="
+          "range": "bytes=700-1044",
+          "checksum": "sha1-yRCBPlJijvUTQJpBTWP+MHT2D8A="
         },
         "data": {
-          "range": "bytes=1050-416967",
-          "checksum": "sha256-hpdMXniZw63PaegccAq9UvA4G8bZ1OkNxIdAMjdYE70="
+          "range": "bytes=1045-416966",
+          "checksum": "sha256-SYFhAsz3YuZICPwI7wN3IcQTd/xSH/ByYzzqmurK0Js="
         }
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-698",
-          "checksum": "sha1-1AptYsIx6ZylY2U2/emVcesdBZ0="
+          "range": "bytes=0-699",
+          "checksum": "sha1-RfviNP7s2tnz3c3t7uFVXy5pOHY="
         },
         "control": {
-          "range": "bytes=699-1306",
-          "checksum": "sha1-jk31YFY5xASRDIRznifI1V6yg5A="
+          "range": "bytes=700-1307",
+          "checksum": "sha1-fSgAC/WGQifn2sDPv25EL73z1h0="
         },
         "data": {
-          "range": "bytes=1307-6656589",
-          "checksum": "sha256-FffcStTm+crzwRilK1F0C4pYgKd8dNhrTky1FRYQJEQ="
+          "range": "bytes=1308-6656588",
+          "checksum": "sha256-n6tptyg9cb6NchzSOEARa2N5AJXkkWiEiXjgH/bZ5Vg="
         }
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-698",
-          "checksum": "sha1-soMdWpWoIEfwKMO0DI7t2UvHfcY="
+          "range": "bytes=0-703",
+          "checksum": "sha1-/T2lI1AsuGMWIgKS2LnMFM3VtlU="
         },
         "control": {
-          "range": "bytes=699-1034",
-          "checksum": "sha1-+xO6A2kusoxvDV+jCUlDIJQJ2iA="
+          "range": "bytes=704-1041",
+          "checksum": "sha1-ZZJYUo8AAkKyRtvpn3B4lW3u+9Q="
         },
         "data": {
-          "range": "bytes=1035-87923",
-          "checksum": "sha256-7G6OzKf2dORUj55LI7qYabbjO6txyOdZwDgQvpjHjcs="
+          "range": "bytes=1042-87924",
+          "checksum": "sha256-1kPfNxgSfVfy4qQ7gVsyQA2sb9n7JLAtAk9d9f+gzHo="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-+LC7d3W/zC1ERWWHLbvk2Go7wic="
+          "range": "bytes=0-708",
+          "checksum": "sha1-AWOTa3MYJyGzHe7kwp3Q43ckCWw="
         },
         "control": {
-          "range": "bytes=698-1070",
-          "checksum": "sha1-1omNq1L3m6lghhTJbMnNrfYfD8s="
+          "range": "bytes=709-1082",
+          "checksum": "sha1-cMmuf4sCR89oRO9ioiyAfENtwLE="
         },
         "data": {
-          "range": "bytes=1071-5696285",
-          "checksum": "sha256-7cfMFTqPGRoShuREE23irXLzZTc6Q8arKtMmTZPAXkQ="
+          "range": "bytes=1083-5696310",
+          "checksum": "sha256-IR44KZDAir4nDHxvFH03w268JC6nlE2aqfMncAan84c="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-695",
-          "checksum": "sha1-ZgOy2VAqmNqEO58+UXJuEJfiqhw="
+          "range": "bytes=0-697",
+          "checksum": "sha1-Xug53GN19xrs8zL8t/DuS66rXuQ="
         },
         "control": {
-          "range": "bytes=696-1067",
-          "checksum": "sha1-he1XFgHS8HIejFrqWgLR3zrzjDQ="
+          "range": "bytes=698-1070",
+          "checksum": "sha1-U0a4yD5Y5R1CZJAFSpgNlOZrIos="
         },
         "data": {
-          "range": "bytes=1068-802541",
-          "checksum": "sha256-sohTytnObGxG4AtuLCKE88Ou/x3cHIVjP7gvs/uIcmc="
+          "range": "bytes=1071-802542",
+          "checksum": "sha256-TsGX/9m1EPr8kFJITdoWd1MkD/apOIQkXMSV1wXsegs="
         }
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3-r1.apk",
-        "version": "1.3-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3-r2.apk",
+        "version": "1.3-r2",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-/Jk5bXHOt0V2n9D4C+Gx7hgKHlU="
+          "range": "bytes=0-700",
+          "checksum": "sha1-lx9f02YRdXv0hv7FriyHxBeecVw="
         },
         "control": {
-          "range": "bytes=704-1085",
-          "checksum": "sha1-C2wS5x5vrJbz/DE/uBsR5vNazy8="
+          "range": "bytes=701-1082",
+          "checksum": "sha1-DCU2NY6Rs8MpfdUYVgFQ++IK+qg="
         },
         "data": {
-          "range": "bytes=1086-156557",
-          "checksum": "sha256-wNV8B31etngwZFQhu6Oh2IZ2yNKCAJSb0kJc/0xXMc4="
+          "range": "bytes=1083-156557",
+          "checksum": "sha256-bQFWa8+q+iPbve7WnlPoFKT0tc5vxbkJUkF/WEj8C+M="
         }
       },
       {

--- a/examples/oci/apko.resolved.json
+++ b/examples/oci/apko.resolved.json
@@ -112,56 +112,56 @@
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-4aNhc3nqFpzcC4jHBFZq+ZC+H4E="
+          "range": "bytes=0-699",
+          "checksum": "sha1-5W7sPjc8XkeOKSkJFYlP8xQQx2s="
         },
         "control": {
-          "range": "bytes=701-1035",
-          "checksum": "sha1-PitIgJfOQtIhoDJRkc8o4qOyrM4="
+          "range": "bytes=700-1034",
+          "checksum": "sha1-MxQCyBxrYF9/SQtwuug2IxAag2s="
         },
         "data": {
-          "range": "bytes=1036-87925",
-          "checksum": "sha256-+Elk6pIvIJRTeKG9t9//cdnaT2BrfE46X5zg3E0mECA="
+          "range": "bytes=1035-87934",
+          "checksum": "sha256-vNVrzURfLpgh3TYwvri0YaN1f9uP8OOOtu+C3A5r/MQ="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-z8f+mPV44TpZDvrelzOmnA1Oym8="
+          "range": "bytes=0-703",
+          "checksum": "sha1-1LnbG68ebL7Bhee1iapnp2+LGGk="
         },
         "control": {
-          "range": "bytes=698-1084",
-          "checksum": "sha1-oonZppas7CIEQE5ehp4w4CquAJs="
+          "range": "bytes=704-1089",
+          "checksum": "sha1-dtZ1Z+s47m2J5hepxlMVRGK/FT4="
         },
         "data": {
-          "range": "bytes=1085-4821143",
-          "checksum": "sha256-FRs9dlQQnlEzpPZSy4WtWDliQI/qieTIHVz5YuMwYWI="
+          "range": "bytes=1090-4972734",
+          "checksum": "sha256-vmMyFpheu/oj38dqxi1HaVlYyPuKnrNlgpDrCVT3jIs="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-704",
-          "checksum": "sha1-VoEhGUsS+iEZ5bCjH2neNirBGMk="
+          "range": "bytes=0-699",
+          "checksum": "sha1-wV6Qk7pvBx1g0AOukyOt4FHPF4I="
         },
         "control": {
-          "range": "bytes=705-1088",
-          "checksum": "sha1-BIe7kw60ABsKvB763uT33UzRK7M="
+          "range": "bytes=700-1081",
+          "checksum": "sha1-ZMt0V0SnkCxZ+rVwbyO3b3YP9vM="
         },
         "data": {
-          "range": "bytes=1089-812711",
-          "checksum": "sha256-8P0POxdIJFw75ojZAq/WxeM8h5bWQu0bWX4E8ESpvlc="
+          "range": "bytes=1082-1130998",
+          "checksum": "sha256-3z7sOXBIFsYA4YTkLFKg0uqvkOamr6f2lrucNUU+N5Y="
         }
       },
       {
@@ -364,56 +364,56 @@
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-/T2lI1AsuGMWIgKS2LnMFM3VtlU="
+          "range": "bytes=0-697",
+          "checksum": "sha1-VccH1xt76d4q4NqO2DesP8w1rqU="
         },
         "control": {
-          "range": "bytes=704-1041",
-          "checksum": "sha1-ZZJYUo8AAkKyRtvpn3B4lW3u+9Q="
+          "range": "bytes=698-1035",
+          "checksum": "sha1-e+hwE3mYrW9g8yHQu6oqmBRBwOw="
         },
         "data": {
-          "range": "bytes=1042-87924",
-          "checksum": "sha256-1kPfNxgSfVfy4qQ7gVsyQA2sb9n7JLAtAk9d9f+gzHo="
+          "range": "bytes=1036-87933",
+          "checksum": "sha256-XRYVqaGoS9WbL4PiDbIf77Wb/9P09hfh0e79oIpsioM="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-708",
-          "checksum": "sha1-AWOTa3MYJyGzHe7kwp3Q43ckCWw="
+          "range": "bytes=0-704",
+          "checksum": "sha1-9kQPC2FvQx/v+vSG2DOXwoZEz+M="
         },
         "control": {
-          "range": "bytes=709-1082",
-          "checksum": "sha1-cMmuf4sCR89oRO9ioiyAfENtwLE="
+          "range": "bytes=705-1076",
+          "checksum": "sha1-PssMPijjO5cb/9HPMy2kIIsMeRg="
         },
         "data": {
-          "range": "bytes=1083-5696310",
-          "checksum": "sha256-IR44KZDAir4nDHxvFH03w268JC6nlE2aqfMncAan84c="
+          "range": "bytes=1077-5890781",
+          "checksum": "sha256-xOCbEaNh4HPDITw5MTCS41dcqiEwkFhDqrTbkxmVqio="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-Xug53GN19xrs8zL8t/DuS66rXuQ="
+          "range": "bytes=0-703",
+          "checksum": "sha1-Ke9S2HaFpS7a4YuWfI8Vdfw9bAE="
         },
         "control": {
-          "range": "bytes=698-1070",
-          "checksum": "sha1-U0a4yD5Y5R1CZJAFSpgNlOZrIos="
+          "range": "bytes=704-1076",
+          "checksum": "sha1-ZxNrny0+ZDgPHFBxhfDrZvjYKx8="
         },
         "data": {
-          "range": "bytes=1071-802542",
-          "checksum": "sha256-TsGX/9m1EPr8kFJITdoWd1MkD/apOIQkXMSV1wXsegs="
+          "range": "bytes=1077-1135349",
+          "checksum": "sha256-NmZhgcI0Nlkvnl9wtPZsdYZpKC3bOzN2J4g2ZCEocs8="
         }
       },
       {

--- a/examples/resolve.sh
+++ b/examples/resolve.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -x
+
+for d in $(find . -name apko.yaml); do
+  (
+    cd $(dirname ${d})
+    docker run -v "$PWD":/work cgr.dev/chainguard/apko@sha256:d5e219c1ceb2e7d56a5933df54819467e5b3331098ea8bebc996fdd30f974f33 resolve /work/apko.yaml
+  )
+done

--- a/examples/wolfi-base/apko.resolved.json
+++ b/examples/wolfi-base/apko.resolved.json
@@ -112,56 +112,56 @@
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-/T2lI1AsuGMWIgKS2LnMFM3VtlU="
+          "range": "bytes=0-697",
+          "checksum": "sha1-VccH1xt76d4q4NqO2DesP8w1rqU="
         },
         "control": {
-          "range": "bytes=704-1041",
-          "checksum": "sha1-ZZJYUo8AAkKyRtvpn3B4lW3u+9Q="
+          "range": "bytes=698-1035",
+          "checksum": "sha1-e+hwE3mYrW9g8yHQu6oqmBRBwOw="
         },
         "data": {
-          "range": "bytes=1042-87924",
-          "checksum": "sha256-1kPfNxgSfVfy4qQ7gVsyQA2sb9n7JLAtAk9d9f+gzHo="
+          "range": "bytes=1036-87933",
+          "checksum": "sha256-XRYVqaGoS9WbL4PiDbIf77Wb/9P09hfh0e79oIpsioM="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-708",
-          "checksum": "sha1-AWOTa3MYJyGzHe7kwp3Q43ckCWw="
+          "range": "bytes=0-704",
+          "checksum": "sha1-9kQPC2FvQx/v+vSG2DOXwoZEz+M="
         },
         "control": {
-          "range": "bytes=709-1082",
-          "checksum": "sha1-cMmuf4sCR89oRO9ioiyAfENtwLE="
+          "range": "bytes=705-1076",
+          "checksum": "sha1-PssMPijjO5cb/9HPMy2kIIsMeRg="
         },
         "data": {
-          "range": "bytes=1083-5696310",
-          "checksum": "sha256-IR44KZDAir4nDHxvFH03w268JC6nlE2aqfMncAan84c="
+          "range": "bytes=1077-5890781",
+          "checksum": "sha256-xOCbEaNh4HPDITw5MTCS41dcqiEwkFhDqrTbkxmVqio="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-Xug53GN19xrs8zL8t/DuS66rXuQ="
+          "range": "bytes=0-703",
+          "checksum": "sha1-Ke9S2HaFpS7a4YuWfI8Vdfw9bAE="
         },
         "control": {
-          "range": "bytes=698-1070",
-          "checksum": "sha1-U0a4yD5Y5R1CZJAFSpgNlOZrIos="
+          "range": "bytes=704-1076",
+          "checksum": "sha1-ZxNrny0+ZDgPHFBxhfDrZvjYKx8="
         },
         "data": {
-          "range": "bytes=1071-802542",
-          "checksum": "sha256-TsGX/9m1EPr8kFJITdoWd1MkD/apOIQkXMSV1wXsegs="
+          "range": "bytes=1077-1135349",
+          "checksum": "sha256-NmZhgcI0Nlkvnl9wtPZsdYZpKC3bOzN2J4g2ZCEocs8="
         }
       },
       {
@@ -364,56 +364,56 @@
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-4aNhc3nqFpzcC4jHBFZq+ZC+H4E="
+          "range": "bytes=0-699",
+          "checksum": "sha1-5W7sPjc8XkeOKSkJFYlP8xQQx2s="
         },
         "control": {
-          "range": "bytes=701-1035",
-          "checksum": "sha1-PitIgJfOQtIhoDJRkc8o4qOyrM4="
+          "range": "bytes=700-1034",
+          "checksum": "sha1-MxQCyBxrYF9/SQtwuug2IxAag2s="
         },
         "data": {
-          "range": "bytes=1036-87925",
-          "checksum": "sha256-+Elk6pIvIJRTeKG9t9//cdnaT2BrfE46X5zg3E0mECA="
+          "range": "bytes=1035-87934",
+          "checksum": "sha256-vNVrzURfLpgh3TYwvri0YaN1f9uP8OOOtu+C3A5r/MQ="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-z8f+mPV44TpZDvrelzOmnA1Oym8="
+          "range": "bytes=0-703",
+          "checksum": "sha1-1LnbG68ebL7Bhee1iapnp2+LGGk="
         },
         "control": {
-          "range": "bytes=698-1084",
-          "checksum": "sha1-oonZppas7CIEQE5ehp4w4CquAJs="
+          "range": "bytes=704-1089",
+          "checksum": "sha1-dtZ1Z+s47m2J5hepxlMVRGK/FT4="
         },
         "data": {
-          "range": "bytes=1085-4821143",
-          "checksum": "sha256-FRs9dlQQnlEzpPZSy4WtWDliQI/qieTIHVz5YuMwYWI="
+          "range": "bytes=1090-4972734",
+          "checksum": "sha256-vmMyFpheu/oj38dqxi1HaVlYyPuKnrNlgpDrCVT3jIs="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.1.4-r1.apk",
-        "version": "3.1.4-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.2.0-r0.apk",
+        "version": "3.2.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-704",
-          "checksum": "sha1-VoEhGUsS+iEZ5bCjH2neNirBGMk="
+          "range": "bytes=0-699",
+          "checksum": "sha1-wV6Qk7pvBx1g0AOukyOt4FHPF4I="
         },
         "control": {
-          "range": "bytes=705-1088",
-          "checksum": "sha1-BIe7kw60ABsKvB763uT33UzRK7M="
+          "range": "bytes=700-1081",
+          "checksum": "sha1-ZMt0V0SnkCxZ+rVwbyO3b3YP9vM="
         },
         "data": {
-          "range": "bytes=1089-812711",
-          "checksum": "sha256-8P0POxdIJFw75ojZAq/WxeM8h5bWQu0bWX4E8ESpvlc="
+          "range": "bytes=1082-1130998",
+          "checksum": "sha256-3z7sOXBIFsYA4YTkLFKg0uqvkOamr6f2lrucNUU+N5Y="
         }
       },
       {

--- a/examples/wolfi-base/apko.resolved.json
+++ b/examples/wolfi-base/apko.resolved.json
@@ -58,128 +58,128 @@
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-702",
-          "checksum": "sha1-oAK7/0OTHBqjV/x0qqWORgyzoLU="
+          "checksum": "sha1-Twc8OsnLpiLGr1glsxwizLwFm6w="
         },
         "control": {
-          "range": "bytes=703-1086",
-          "checksum": "sha1-iWbLQvCYR2Y6zYJrlKokB14B8hk="
+          "range": "bytes=703-1098",
+          "checksum": "sha1-yRtxTKuHnEGufUD0mlqieHDebDQ="
         },
         "data": {
-          "range": "bytes=1087-266151",
-          "checksum": "sha256-1CNocW3KOzKCJK5++DeAGStj2EAKsnyxIDEDBRRLUDk="
+          "range": "bytes=1099-266150",
+          "checksum": "sha256-6iPIpa/6dq+RZoFex1CmoSSaI6mEN6d8cv4l0YfqiC8="
         }
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-704",
-          "checksum": "sha1-XGqaE5/cq6rT85KSaVpHqmBeW4o="
+          "range": "bytes=0-699",
+          "checksum": "sha1-ySFnkUiQl1nB8rfphClg+mWZCSk="
         },
         "control": {
-          "range": "bytes=705-1049",
-          "checksum": "sha1-vY6oBBxN635Sy2L6y/wgvjpBeh0="
+          "range": "bytes=700-1044",
+          "checksum": "sha1-yRCBPlJijvUTQJpBTWP+MHT2D8A="
         },
         "data": {
-          "range": "bytes=1050-416967",
-          "checksum": "sha256-hpdMXniZw63PaegccAq9UvA4G8bZ1OkNxIdAMjdYE70="
+          "range": "bytes=1045-416966",
+          "checksum": "sha256-SYFhAsz3YuZICPwI7wN3IcQTd/xSH/ByYzzqmurK0Js="
         }
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-698",
-          "checksum": "sha1-1AptYsIx6ZylY2U2/emVcesdBZ0="
+          "range": "bytes=0-699",
+          "checksum": "sha1-RfviNP7s2tnz3c3t7uFVXy5pOHY="
         },
         "control": {
-          "range": "bytes=699-1306",
-          "checksum": "sha1-jk31YFY5xASRDIRznifI1V6yg5A="
+          "range": "bytes=700-1307",
+          "checksum": "sha1-fSgAC/WGQifn2sDPv25EL73z1h0="
         },
         "data": {
-          "range": "bytes=1307-6656589",
-          "checksum": "sha256-FffcStTm+crzwRilK1F0C4pYgKd8dNhrTky1FRYQJEQ="
+          "range": "bytes=1308-6656588",
+          "checksum": "sha256-n6tptyg9cb6NchzSOEARa2N5AJXkkWiEiXjgH/bZ5Vg="
         }
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-698",
-          "checksum": "sha1-soMdWpWoIEfwKMO0DI7t2UvHfcY="
+          "range": "bytes=0-703",
+          "checksum": "sha1-/T2lI1AsuGMWIgKS2LnMFM3VtlU="
         },
         "control": {
-          "range": "bytes=699-1034",
-          "checksum": "sha1-+xO6A2kusoxvDV+jCUlDIJQJ2iA="
+          "range": "bytes=704-1041",
+          "checksum": "sha1-ZZJYUo8AAkKyRtvpn3B4lW3u+9Q="
         },
         "data": {
-          "range": "bytes=1035-87923",
-          "checksum": "sha256-7G6OzKf2dORUj55LI7qYabbjO6txyOdZwDgQvpjHjcs="
+          "range": "bytes=1042-87924",
+          "checksum": "sha256-1kPfNxgSfVfy4qQ7gVsyQA2sb9n7JLAtAk9d9f+gzHo="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-+LC7d3W/zC1ERWWHLbvk2Go7wic="
+          "range": "bytes=0-708",
+          "checksum": "sha1-AWOTa3MYJyGzHe7kwp3Q43ckCWw="
         },
         "control": {
-          "range": "bytes=698-1070",
-          "checksum": "sha1-1omNq1L3m6lghhTJbMnNrfYfD8s="
+          "range": "bytes=709-1082",
+          "checksum": "sha1-cMmuf4sCR89oRO9ioiyAfENtwLE="
         },
         "data": {
-          "range": "bytes=1071-5696285",
-          "checksum": "sha256-7cfMFTqPGRoShuREE23irXLzZTc6Q8arKtMmTZPAXkQ="
+          "range": "bytes=1083-5696310",
+          "checksum": "sha256-IR44KZDAir4nDHxvFH03w268JC6nlE2aqfMncAan84c="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-695",
-          "checksum": "sha1-ZgOy2VAqmNqEO58+UXJuEJfiqhw="
+          "range": "bytes=0-697",
+          "checksum": "sha1-Xug53GN19xrs8zL8t/DuS66rXuQ="
         },
         "control": {
-          "range": "bytes=696-1067",
-          "checksum": "sha1-he1XFgHS8HIejFrqWgLR3zrzjDQ="
+          "range": "bytes=698-1070",
+          "checksum": "sha1-U0a4yD5Y5R1CZJAFSpgNlOZrIos="
         },
         "data": {
-          "range": "bytes=1068-802541",
-          "checksum": "sha256-sohTytnObGxG4AtuLCKE88Ou/x3cHIVjP7gvs/uIcmc="
+          "range": "bytes=1071-802542",
+          "checksum": "sha256-TsGX/9m1EPr8kFJITdoWd1MkD/apOIQkXMSV1wXsegs="
         }
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3-r1.apk",
-        "version": "1.3-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3-r2.apk",
+        "version": "1.3-r2",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-/Jk5bXHOt0V2n9D4C+Gx7hgKHlU="
+          "range": "bytes=0-700",
+          "checksum": "sha1-lx9f02YRdXv0hv7FriyHxBeecVw="
         },
         "control": {
-          "range": "bytes=704-1085",
-          "checksum": "sha1-C2wS5x5vrJbz/DE/uBsR5vNazy8="
+          "range": "bytes=701-1082",
+          "checksum": "sha1-DCU2NY6Rs8MpfdUYVgFQ++IK+qg="
         },
         "data": {
-          "range": "bytes=1086-156557",
-          "checksum": "sha256-wNV8B31etngwZFQhu6Oh2IZ2yNKCAJSb0kJc/0xXMc4="
+          "range": "bytes=1083-156557",
+          "checksum": "sha256-bQFWa8+q+iPbve7WnlPoFKT0tc5vxbkJUkF/WEj8C+M="
         }
       },
       {
@@ -310,128 +310,128 @@
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-702",
-          "checksum": "sha1-aH8ZN12tAaPnT4Aw/hJuoERJIKA="
+          "range": "bytes=0-700",
+          "checksum": "sha1-bc/LYdjt1YRKBVqFo0OCWrLDsW4="
         },
         "control": {
-          "range": "bytes=703-1082",
-          "checksum": "sha1-8/M0yEAgqQ3jqVOcRGGLBkBgTtc="
+          "range": "bytes=701-1095",
+          "checksum": "sha1-VOuDI6cngPUe0QMmQTSmAsD6cEY="
         },
         "data": {
-          "range": "bytes=1083-265292",
-          "checksum": "sha256-cc1gzWdor8ICfMstalLxu6iiVvwcTC3gFcrQTdEoHr0="
+          "range": "bytes=1096-265291",
+          "checksum": "sha256-kY0/ezJ2DVrUT2X/oRrXuoiUzfGIXtn3E2owX3JckmQ="
         }
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-701",
-          "checksum": "sha1-BtvtMwa73foDRk9FFY8vfOjKlcA="
+          "range": "bytes=0-705",
+          "checksum": "sha1-H6DEtQIVLnNrXc0r+DcUglYx4Q0="
         },
         "control": {
-          "range": "bytes=702-1043",
-          "checksum": "sha1-P4sTiJm/tqHhC3EkyEYv6WIhELg="
+          "range": "bytes=706-1048",
+          "checksum": "sha1-PVoyenqq3cd0c4fNbErXj3Fma/U="
         },
         "data": {
-          "range": "bytes=1044-416968",
-          "checksum": "sha256-0b2RdCPyUbNNAQSIIJUm8f6Tk0IJwqmvFdpbMpLMExo="
+          "range": "bytes=1049-416967",
+          "checksum": "sha256-q5DBf/WP90hZEKQPr6WXvmZHWaXzRRrFdVsToSR/a7g="
         }
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.38-r6.apk",
+        "version": "2.38-r6",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-699",
-          "checksum": "sha1-j2AQEBUim9hUaC/OJprkdj25+uU="
+          "checksum": "sha1-R8Wr6MgRmGcNHhEi+fouU7SuLtQ="
         },
         "control": {
           "range": "bytes=700-1304",
-          "checksum": "sha1-vupFS8FOeEUOyb6COYGFhQdAonk="
+          "checksum": "sha1-CnMimmBZKU82tMyI5H26UMN6l4I="
         },
         "data": {
-          "range": "bytes=1305-5592271",
-          "checksum": "sha256-vrOifwV6UX3fC1CQQbccbTKbsZtZAZQHRD0VOfrNGYU="
+          "range": "bytes=1305-5592270",
+          "checksum": "sha256-+eWbn5IaCaRs8lB21Pzlfeefho7eb4pIDKMW/6fJMxs="
         }
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-qInWK2AkbXyzmXwQrle1XRqvFLg="
+          "range": "bytes=0-700",
+          "checksum": "sha1-4aNhc3nqFpzcC4jHBFZq+ZC+H4E="
         },
         "control": {
-          "range": "bytes=698-1031",
-          "checksum": "sha1-Bm5JSQB4MbwHXrb0sImXRZM4q6Y="
+          "range": "bytes=701-1035",
+          "checksum": "sha1-PitIgJfOQtIhoDJRkc8o4qOyrM4="
         },
         "data": {
-          "range": "bytes=1032-87924",
-          "checksum": "sha256-n0vQFv6ZagoGu3WSZZZeyb+vxsctdWVgelTlrbhE+mA="
+          "range": "bytes=1036-87925",
+          "checksum": "sha256-+Elk6pIvIJRTeKG9t9//cdnaT2BrfE46X5zg3E0mECA="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-l+OV+d9JsTq9z/XnkV+81NoeO8k="
+          "range": "bytes=0-697",
+          "checksum": "sha1-z8f+mPV44TpZDvrelzOmnA1Oym8="
         },
         "control": {
-          "range": "bytes=704-1090",
-          "checksum": "sha1-F56yGwaHrU8muAlvSzUfIjg9MZs="
+          "range": "bytes=698-1084",
+          "checksum": "sha1-oonZppas7CIEQE5ehp4w4CquAJs="
         },
         "data": {
-          "range": "bytes=1091-4821118",
-          "checksum": "sha256-GJjCDboTV3320kbipKmCcJaNVE10GZHfE4gTfPNp8kE="
+          "range": "bytes=1085-4821143",
+          "checksum": "sha256-FRs9dlQQnlEzpPZSy4WtWDliQI/qieTIHVz5YuMwYWI="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.1.4-r0.apk",
-        "version": "3.1.4-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.1.4-r1.apk",
+        "version": "3.1.4-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-b6CIWM1fcf5AT2Qu0QjJNJ2nPfU="
+          "range": "bytes=0-704",
+          "checksum": "sha1-VoEhGUsS+iEZ5bCjH2neNirBGMk="
         },
         "control": {
-          "range": "bytes=701-1084",
-          "checksum": "sha1-mop3B1o8c/n/+iHMkFV3Sod61zc="
+          "range": "bytes=705-1088",
+          "checksum": "sha1-BIe7kw60ABsKvB763uT33UzRK7M="
         },
         "data": {
-          "range": "bytes=1085-812710",
-          "checksum": "sha256-ddCg2RwL64xSDPoz9O5jcC1AwMVs1VfDAdiMOBVma30="
+          "range": "bytes=1089-812711",
+          "checksum": "sha256-8P0POxdIJFw75ojZAq/WxeM8h5bWQu0bWX4E8ESpvlc="
         }
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3-r1.apk",
-        "version": "1.3-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3-r2.apk",
+        "version": "1.3-r2",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-BE9hw48pQ/4tg+RyoN+z0KP0sko="
+          "range": "bytes=0-700",
+          "checksum": "sha1-1S276hPYl+9ssemIoJG7TYGfAMM="
         },
         "control": {
-          "range": "bytes=700-1097",
-          "checksum": "sha1-tN0HwtJtpOkMRrRk2w1rfM2mE3Y="
+          "range": "bytes=701-1095",
+          "checksum": "sha1-WYRIXWM96qWE1c0WhV4TM+qSTko="
         },
         "data": {
-          "range": "bytes=1098-191294",
-          "checksum": "sha256-Xzfhp8cXnqEo8ywHmOf2KzBX9JLNU27d2LNZ9MA20pU="
+          "range": "bytes=1096-191254",
+          "checksum": "sha256-i4AaBbeXFdD3FXVsbKC6T9SmUXIrDGkn/wbj+9PX8Lo="
         }
       },
       {


### PR DESCRIPTION
Do not depend on the alpine/edge (as resolved artifacts are dangling).
Instead depend on the stable `v3.18`.

In general it's a bad practice when `bazel test //...` brakes because someone else (periodic) actions.

The same problem applies to Wolfi... (without artifacts cache).

After this PR: `bazel test //...` works.