### PR TITLE
Relax requirements for stable SHA on the signature part of the package

### DIFF
--- a/examples/multi_arch_and_repo/apko.resolved.json
+++ b/examples/multi_arch_and_repo/apko.resolved.json
@@ -333,20 +333,20 @@
       },
       {
         "name": "libcurl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libcurl-8.4.0-r0.apk",
-        "version": "8.4.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libcurl-8.5.0-r0.apk",
+        "version": "8.5.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-667",
-          "checksum": "sha1-+qUfnAHSeI3WSmgYuP6Zkb3dtrI="
+          "range": "bytes=0-666",
+          "checksum": "sha1-xS5Fqf9WGd8zntG43VnVmv718r0="
         },
         "control": {
-          "range": "bytes=668-1257",
-          "checksum": "sha1-gPf4xljVT4LCLL/LacYdcuDId28="
+          "range": "bytes=667-1258",
+          "checksum": "sha1-wh2mSAWikJtRT8JTBT8yXHK3eO0="
         },
         "data": {
-          "range": "bytes=1258-684032",
-          "checksum": "sha256-qNyxFzcgWmzhqd6p4ag/FFrwttjNyM+ZDmay1JCtdrA="
+          "range": "bytes=1259-684032",
+          "checksum": "sha256-vVYvw3b+zVt97Vcy0HQY1XNoQZk2atEZfw+15aRbVcI="
         }
       },
       {
@@ -369,20 +369,20 @@
       },
       {
         "name": "curl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/curl-8.4.0-r0.apk",
-        "version": "8.4.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/curl-8.5.0-r0.apk",
+        "version": "8.5.0-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-tHlf9OQOzSjYkTRXYsBdF1ns/jk="
+          "range": "bytes=0-666",
+          "checksum": "sha1-WYjHDJ4IBadYkXdr8UGZlmS+nqg="
         },
         "control": {
-          "range": "bytes=663-1208",
-          "checksum": "sha1-NJnlr4Up2hhq7YnlXBVFST5wEiM="
+          "range": "bytes=667-1215",
+          "checksum": "sha1-/IDNLWm+swS1gfitZjIOnGTA+Sc="
         },
         "data": {
-          "range": "bytes=1209-278528",
-          "checksum": "sha256-ENmDbt7laYTIqVbFBIqIqi2a1pGZTmYEvSWt9T9XtXw="
+          "range": "bytes=1216-344064",
+          "checksum": "sha256-wDYqeyPrMzyyR0BSmX7Kcd8qNmXGhSOLSG+9M4FL+8I="
         }
       },
       {
@@ -495,20 +495,20 @@
       },
       {
         "name": "jq",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/jq-1.6-r3.apk",
-        "version": "1.6-r3",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/jq-1.6-r4.apk",
+        "version": "1.6-r4",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-A4nhkN/96UgBJbIeQnerGNiDcTQ="
+          "range": "bytes=0-662",
+          "checksum": "sha1-gq29wucloRZ957Q7e80YnoWC5Mk="
         },
         "control": {
-          "range": "bytes=664-1276",
-          "checksum": "sha1-bE8DJ2EMXuuIQJu6heONhhH6n3A="
+          "range": "bytes=663-1246",
+          "checksum": "sha1-0nfz6LGXaODGWiz6Qnzj7Y7tIg4="
         },
         "data": {
-          "range": "bytes=1277-679936",
-          "checksum": "sha256-gqEeVd61YkdNuzcO8xTYSM2AKPAFmRyoBrrvrtKAAZI="
+          "range": "bytes=1247-679936",
+          "checksum": "sha256-h3Ku4d0tkpQy8Wa8XuNIiZ4yj3MvoK1ANOFN99PEWx4="
         }
       },
       {
@@ -1071,20 +1071,20 @@
       },
       {
         "name": "libcurl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libcurl-8.4.0-r0.apk",
-        "version": "8.4.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libcurl-8.5.0-r0.apk",
+        "version": "8.5.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-Q1/zQGYYbFfpHfx4oYYF6jzv/5g="
+          "range": "bytes=0-665",
+          "checksum": "sha1-AuogH2CSLstnZ37bqeizqy4bsvk="
         },
         "control": {
-          "range": "bytes=664-1271",
-          "checksum": "sha1-xBpvkAuwlXJ/cG7VPdUv809YbMg="
+          "range": "bytes=666-1275",
+          "checksum": "sha1-rSeJPoRcRdLTweUC2PkOGXCQnUw="
         },
         "data": {
-          "range": "bytes=1272-598016",
-          "checksum": "sha256-NkUn30Hnf3TlPLsjEcOOcKm/QAd5EaYSLxEx3ENtix0="
+          "range": "bytes=1276-598016",
+          "checksum": "sha256-7RjidWfUbpj2KsS4+mxnmpEPSMFxFHJQ72WU2TtTlkY="
         }
       },
       {
@@ -1107,20 +1107,20 @@
       },
       {
         "name": "curl",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/curl-8.4.0-r0.apk",
-        "version": "8.4.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/curl-8.5.0-r0.apk",
+        "version": "8.5.0-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-lu7pVWiIVlqyle+tLYZVaay/k/Y="
+          "range": "bytes=0-665",
+          "checksum": "sha1-mHNmgXQlebuRUK/1Sj7DHahu90k="
         },
         "control": {
-          "range": "bytes=665-1229",
-          "checksum": "sha1-dniSzRZDzQc9a6aEa380UuOFG3s="
+          "range": "bytes=666-1232",
+          "checksum": "sha1-oSBerwcr+l8IBT+vBOsovgBwQRo="
         },
         "data": {
-          "range": "bytes=1230-253952",
-          "checksum": "sha256-GSEimu+Su3k/4xYITuxSUO/+F5F/uNfkUWhe6+z7h5U="
+          "range": "bytes=1233-253952",
+          "checksum": "sha256-C5xCvleBxFHYqSwr9I2BLOZu0e7GBRlwKs+mQK1a+f0="
         }
       },
       {
@@ -1233,20 +1233,20 @@
       },
       {
         "name": "jq",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/jq-1.6-r3.apk",
-        "version": "1.6-r3",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/jq-1.6-r4.apk",
+        "version": "1.6-r4",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-tPzFzR0wFiPQg7XcnQiGy/YeeFg="
+          "range": "bytes=0-662",
+          "checksum": "sha1-L0/Ps35FjUjxiSvUF75hYn9Zq3M="
         },
         "control": {
-          "range": "bytes=664-1277",
-          "checksum": "sha1-a+tNKTUC2Ed/MMtRWWOXvc3f2F8="
+          "range": "bytes=663-1273",
+          "checksum": "sha1-hqoIW3vrc9MEO5QvXIYCC/oNE5E="
         },
         "data": {
-          "range": "bytes=1278-557056",
-          "checksum": "sha256-K0xZfugjpGym0YtX1lJKmgFRqEw1mlw3lvXr1MdN3zA="
+          "range": "bytes=1274-557056",
+          "checksum": "sha256-wAIJBCnTC0jwc5vlZ/4paXkeQ78NtjuiinSqZKrvgII="
         }
       },
       {

--- a/examples/oci/apko.resolved.json
+++ b/examples/oci/apko.resolved.json
@@ -22,218 +22,218 @@
     "packages": [
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20230506-r0.apk",
-        "version": "20230506-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20230506-r1.apk",
+        "version": "20230506-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-647",
-          "checksum": "sha1-s9/tr3z/dZPicv1OVKz31ysaJQE="
+          "range": "bytes=0-700",
+          "checksum": "sha1-aUXTrOGFmIjd0x+HLCRZvR2X1a0="
         },
         "control": {
-          "range": "bytes=648-935",
-          "checksum": "sha1-N1RG8Ckcg5B0Nlp6kS26dA5WFwY="
+          "range": "bytes=701-1033",
+          "checksum": "sha1-gMuh2d1dY1EY0Ganu9Ls/RRIXUI="
         },
         "data": {
-          "range": "bytes=936-249592",
-          "checksum": "sha256-JounDEIr83QfxnDYPBhlTQylRA7HgcBlgABrHYkIyMk="
+          "range": "bytes=1034-249634",
+          "checksum": "sha256-PpXQiz31ojbE87mPgRa6+ChldVHRHk8HGOUsR1wL44g="
         }
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r6.apk",
-        "version": "20230201-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r7.apk",
+        "version": "20230201-r7",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-698",
-          "checksum": "sha1-7pyg3ZZyuqiKYxS+nOTx8KoRV+8="
+          "checksum": "sha1-PRg1PDX7kg66RMuAOkXYZ4IDJ9I="
         },
         "control": {
           "range": "bytes=699-1046",
-          "checksum": "sha1-1IRhQ5Af8EsskNGI41B61PJKEmQ="
+          "checksum": "sha1-/4xGSMRg+0rCwuLMLe6Yi8k3BSE="
         },
         "data": {
-          "range": "bytes=1047-125392",
-          "checksum": "sha256-8ugMC+WWnVs2LDEgnIjgFy489tBWgjsJGRnK85brHok="
+          "range": "bytes=1047-125428",
+          "checksum": "sha256-r9K9i+RMG6uUWY7L/TrqkZdyNHoU3PnhSez4++ItCiA="
         }
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-bc/LYdjt1YRKBVqFo0OCWrLDsW4="
+          "range": "bytes=0-708",
+          "checksum": "sha1-u0ApCBiurwCwBzVLWXLBOjPWiww="
         },
         "control": {
-          "range": "bytes=701-1095",
-          "checksum": "sha1-VOuDI6cngPUe0QMmQTSmAsD6cEY="
+          "range": "bytes=709-1102",
+          "checksum": "sha1-tQL1lJCaj9X6qz0Zfl/wpT0WAKE="
         },
         "data": {
-          "range": "bytes=1096-265291",
-          "checksum": "sha256-kY0/ezJ2DVrUT2X/oRrXuoiUzfGIXtn3E2owX3JckmQ="
+          "range": "bytes=1103-265349",
+          "checksum": "sha256-hHfanGAvtlWTL40t2AO0N7kAD7xlNfDLcEfPm3/DnZo="
         }
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-705",
-          "checksum": "sha1-H6DEtQIVLnNrXc0r+DcUglYx4Q0="
+          "range": "bytes=0-697",
+          "checksum": "sha1-4+Mp2flaIYKiEJ6XKwtoBTgDjCU="
         },
         "control": {
-          "range": "bytes=706-1048",
-          "checksum": "sha1-PVoyenqq3cd0c4fNbErXj3Fma/U="
+          "range": "bytes=698-1040",
+          "checksum": "sha1-XHNKylXG1NelDm64u3IBf9IVjX0="
         },
         "data": {
-          "range": "bytes=1049-416967",
-          "checksum": "sha256-q5DBf/WP90hZEKQPr6WXvmZHWaXzRRrFdVsToSR/a7g="
+          "range": "bytes=1041-417006",
+          "checksum": "sha256-miBw1ZOB261zgoVG81Yhdf5L1xmWYYV3p6dNAHSxERA="
         }
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-R8Wr6MgRmGcNHhEi+fouU7SuLtQ="
+          "range": "bytes=0-701",
+          "checksum": "sha1-Vc9khIZZTafVjDK78luP9JX6x8g="
         },
         "control": {
-          "range": "bytes=700-1304",
-          "checksum": "sha1-CnMimmBZKU82tMyI5H26UMN6l4I="
+          "range": "bytes=702-1308",
+          "checksum": "sha1-8D31WR0R9iF0kHeeJpZI1AKgagQ="
         },
         "data": {
-          "range": "bytes=1305-5592270",
-          "checksum": "sha256-+eWbn5IaCaRs8lB21Pzlfeefho7eb4pIDKMW/6fJMxs="
+          "range": "bytes=1309-5592315",
+          "checksum": "sha256-57srttgz2wBUOpUmzVeHnaPlPqib97l1cziHW08ulIA="
         }
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-5W7sPjc8XkeOKSkJFYlP8xQQx2s="
+          "range": "bytes=0-700",
+          "checksum": "sha1-p1qaSIYhdFoYjVL7SHjou2SPZYU="
         },
         "control": {
-          "range": "bytes=700-1034",
-          "checksum": "sha1-MxQCyBxrYF9/SQtwuug2IxAag2s="
+          "range": "bytes=701-1033",
+          "checksum": "sha1-7O37tZQFOQvSgQ2mCWEJ0EcbC6o="
         },
         "data": {
-          "range": "bytes=1035-87934",
-          "checksum": "sha256-vNVrzURfLpgh3TYwvri0YaN1f9uP8OOOtu+C3A5r/MQ="
+          "range": "bytes=1034-87982",
+          "checksum": "sha256-J/gaoFoW6EbTdvEO4NzAHfl4dPqEVRl0i3W62+XEJN4="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-1LnbG68ebL7Bhee1iapnp2+LGGk="
+          "range": "bytes=0-706",
+          "checksum": "sha1-OIq+JiPfrRM75nzGi29NwzRqSbk="
         },
         "control": {
-          "range": "bytes=704-1089",
-          "checksum": "sha1-dtZ1Z+s47m2J5hepxlMVRGK/FT4="
+          "range": "bytes=707-1092",
+          "checksum": "sha1-KzSsaxXiKaJ1PEuVfmb/xZttOoA="
         },
         "data": {
-          "range": "bytes=1090-4972734",
-          "checksum": "sha256-vmMyFpheu/oj38dqxi1HaVlYyPuKnrNlgpDrCVT3jIs="
+          "range": "bytes=1093-4972790",
+          "checksum": "sha256-mYxenlqkXj1psWRZQs0+u8qtwf46GM/5oUNtdCuRd4U="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-wV6Qk7pvBx1g0AOukyOt4FHPF4I="
+          "range": "bytes=0-705",
+          "checksum": "sha1-Wk5j5JDG1mI0+l1OiEdKW/HL4T0="
         },
         "control": {
-          "range": "bytes=700-1081",
-          "checksum": "sha1-ZMt0V0SnkCxZ+rVwbyO3b3YP9vM="
+          "range": "bytes=706-1086",
+          "checksum": "sha1-btRuPg8wQIjjOYzRxdp45Z0INuk="
         },
         "data": {
-          "range": "bytes=1082-1130998",
-          "checksum": "sha256-3z7sOXBIFsYA4YTkLFKg0uqvkOamr6f2lrucNUU+N5Y="
+          "range": "bytes=1087-1131058",
+          "checksum": "sha256-f1/PimvUP+YCCwo6Mr6cahHK8jLaWeGnw0dTCSKvt5c="
         }
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3-r2.apk",
-        "version": "1.3-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3-r3.apk",
+        "version": "1.3-r3",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-1S276hPYl+9ssemIoJG7TYGfAMM="
+          "range": "bytes=0-691",
+          "checksum": "sha1-5E6pZh0EM0DyOIx7NwtvlArOW0c="
         },
         "control": {
-          "range": "bytes=701-1095",
-          "checksum": "sha1-WYRIXWM96qWE1c0WhV4TM+qSTko="
+          "range": "bytes=692-1086",
+          "checksum": "sha1-YiAx3eMWhOxqleVmn3gM0olZEKQ="
         },
         "data": {
-          "range": "bytes=1096-191254",
-          "checksum": "sha256-i4AaBbeXFdD3FXVsbKC6T9SmUXIrDGkn/wbj+9PX8Lo="
+          "range": "bytes=1087-191318",
+          "checksum": "sha256-9Du3QlZ09zDdfsS3HxJSvLVIffQXKHuwH6Opl971gZs="
         }
       },
       {
         "name": "apk-tools",
-        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.0-r0.apk",
-        "version": "2.14.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.0-r1.apk",
+        "version": "2.14.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-657",
-          "checksum": "sha1-/pRAL96gP1XHx1k+tRsJZcjl0ec="
+          "range": "bytes=0-700",
+          "checksum": "sha1-8vhyOfegR0P/yaMBcp7+dBGjagM="
         },
         "control": {
-          "range": "bytes=658-1090",
-          "checksum": "sha1-I3OAi6ke9HMmxkiab+4MuJQmdUQ="
+          "range": "bytes=701-1129",
+          "checksum": "sha1-JFLblNleo+XoRzgGSDd6QMUuzSM="
         },
         "data": {
-          "range": "bytes=1091-552340",
-          "checksum": "sha256-VH73KhNt/1S0ukNpkqJq6f73nHK06O7MsAwsZFlUglI="
+          "range": "bytes=1130-605132",
+          "checksum": "sha256-LRI/KNPIkknYLPT4+NK8mIRlB+OVKwc9MbHvoJHuPpc="
         }
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-694",
-          "checksum": "sha1-iDrfPe5FhU3bHhxbaAZ3qyxQTrY="
+          "checksum": "sha1-NwjywwWpfq7FwKm3ZP7jLf/VumQ="
         },
         "control": {
-          "range": "bytes=695-1082",
-          "checksum": "sha1-aSYR0I4tmd4gEFAXxOMSezg18GI="
+          "range": "bytes=695-1081",
+          "checksum": "sha1-0O4IuDHa+IvhWX62aW2Uj0SWyBo="
         },
         "data": {
-          "range": "bytes=1083-101348",
-          "checksum": "sha256-QI8ZnzVe4Hw3niiRdbL9u+aBuDMD+cA5Q0Z6Z3TSAmc="
+          "range": "bytes=1082-101406",
+          "checksum": "sha256-RgeVQFodY5IzTg18nwE9iFAdtNxy9x2qNrNN0SWZ7ks="
         }
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.36.1-r2.apk",
-        "version": "1.36.1-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.36.1-r4.apk",
+        "version": "1.36.1-r4",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-m9X6KDEy74aCpQlKlkegUn5XjOo="
+          "range": "bytes=0-705",
+          "checksum": "sha1-hnv8ydWc0uIHiB1vw/BN+XFYUQY="
         },
         "control": {
-          "range": "bytes=663-1148",
-          "checksum": "sha1-seigbSQse4Xfe9+fcu4mQlROELc="
+          "range": "bytes=706-1196",
+          "checksum": "sha1-NaRv5Dd4ywo+HKbaxeqWrqlSyIw="
         },
         "data": {
-          "range": "bytes=1149-738253",
-          "checksum": "sha256-OAfCAR9diQsN/NifKaGSUalgVuRMlk5Q5QIm/Es0Dy0="
+          "range": "bytes=1197-738309",
+          "checksum": "sha256-06U+CLm2QRJglmzaFbXwLxcruJcPyZuiTsEESjlBLQU="
         }
       },
       {
@@ -274,218 +274,218 @@
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20230506-r0.apk",
-        "version": "20230506-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20230506-r1.apk",
+        "version": "20230506-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-649",
-          "checksum": "sha1-HoqYVacxp/KTeMmeQyrXh6Mqa0w="
+          "range": "bytes=0-696",
+          "checksum": "sha1-8R2wh98RRnJXoDSksgIT/89AkLc="
         },
         "control": {
-          "range": "bytes=650-966",
-          "checksum": "sha1-/YGo3iUSdyF2/rk3tKR6MhtUEzg="
+          "range": "bytes=697-1030",
+          "checksum": "sha1-/kLPUjePSMngiqVtUCW4RJ4E2ts="
         },
         "data": {
-          "range": "bytes=967-249591",
-          "checksum": "sha256-7neBVl819zb1HiRNaW8Ze6E1SPTrvfxytQyCdRTbUrg="
+          "range": "bytes=1031-249633",
+          "checksum": "sha256-G7/jlC0ypBZIx+QAMUa5z/B3p+tm4Itz04emyjG9gFw="
         }
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r6.apk",
-        "version": "20230201-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r7.apk",
+        "version": "20230201-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-B0aZFr+bN3sKl78a/r6g1idipu8="
+          "range": "bytes=0-701",
+          "checksum": "sha1-1CcRiULOFhX8ldA/Ae2qCMUGNmQ="
         },
         "control": {
-          "range": "bytes=701-1049",
-          "checksum": "sha1-7VhAhkjHFu8hi9j6VPHxlOX95sc="
+          "range": "bytes=702-1052",
+          "checksum": "sha1-OHhyuiUviNHTg939DA0lyeRee18="
         },
         "data": {
-          "range": "bytes=1050-125391",
-          "checksum": "sha256-E1YOC4cEwiNxueSte+3mQzPSxBGuAE7D89R3E7gVxYQ="
+          "range": "bytes=1053-125427",
+          "checksum": "sha256-om3EZzEM+3dD9a77sOB2uOuAKBlf7XoUW/ORnDHQvZY="
         }
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-702",
-          "checksum": "sha1-Twc8OsnLpiLGr1glsxwizLwFm6w="
+          "range": "bytes=0-697",
+          "checksum": "sha1-IL3B1HZ2wdNyCOBXYFZGcbBGoqs="
         },
         "control": {
-          "range": "bytes=703-1098",
-          "checksum": "sha1-yRtxTKuHnEGufUD0mlqieHDebDQ="
+          "range": "bytes=698-1093",
+          "checksum": "sha1-fN6EOYCDfkAB0hPHFXGOflxx/io="
         },
         "data": {
-          "range": "bytes=1099-266150",
-          "checksum": "sha256-6iPIpa/6dq+RZoFex1CmoSSaI6mEN6d8cv4l0YfqiC8="
+          "range": "bytes=1094-266208",
+          "checksum": "sha256-EMs+i+Ylu+q91xSbRNeqlqVgqO0WCIY559NT30Stx7U="
         }
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-699",
-          "checksum": "sha1-ySFnkUiQl1nB8rfphClg+mWZCSk="
+          "checksum": "sha1-TgYN2N4ZPQ7UX0v1ZIi/AM8b6AA="
         },
         "control": {
-          "range": "bytes=700-1044",
-          "checksum": "sha1-yRCBPlJijvUTQJpBTWP+MHT2D8A="
+          "range": "bytes=700-1043",
+          "checksum": "sha1-QTmeDpnOOVYHZq8AeVfdK7DSxsE="
         },
         "data": {
-          "range": "bytes=1045-416966",
-          "checksum": "sha256-SYFhAsz3YuZICPwI7wN3IcQTd/xSH/ByYzzqmurK0Js="
+          "range": "bytes=1044-417005",
+          "checksum": "sha256-On9nfE5oODRF1N//C4DT+Ksz50Rk+O7vCqixUP59dv8="
         }
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-RfviNP7s2tnz3c3t7uFVXy5pOHY="
+          "range": "bytes=0-700",
+          "checksum": "sha1-8nqEerTDUCfn8WzV0y2I02S/Kz0="
         },
         "control": {
-          "range": "bytes=700-1307",
-          "checksum": "sha1-fSgAC/WGQifn2sDPv25EL73z1h0="
+          "range": "bytes=701-1311",
+          "checksum": "sha1-1DIBkq6kQLwbvpYZebVCaXDf7x0="
         },
         "data": {
-          "range": "bytes=1308-6656588",
-          "checksum": "sha256-n6tptyg9cb6NchzSOEARa2N5AJXkkWiEiXjgH/bZ5Vg="
+          "range": "bytes=1312-6660729",
+          "checksum": "sha256-m56Xq6r3fySpzAh1aTHVfHx1O1u5V4RPysRESTISJGg="
         }
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-VccH1xt76d4q4NqO2DesP8w1rqU="
+          "range": "bytes=0-699",
+          "checksum": "sha1-lV63/Vm/cSQyXxEtH2TLeQsQrJY="
         },
         "control": {
-          "range": "bytes=698-1035",
-          "checksum": "sha1-e+hwE3mYrW9g8yHQu6oqmBRBwOw="
+          "range": "bytes=700-1032",
+          "checksum": "sha1-kYtyci1iQwFlIvuj7S54ofi436Y="
         },
         "data": {
-          "range": "bytes=1036-87933",
-          "checksum": "sha256-XRYVqaGoS9WbL4PiDbIf77Wb/9P09hfh0e79oIpsioM="
+          "range": "bytes=1033-87981",
+          "checksum": "sha256-Jykzhaq1lMhpTWNAowIKrOh01jr11fVd0Ga1mgBhzxs="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-704",
-          "checksum": "sha1-9kQPC2FvQx/v+vSG2DOXwoZEz+M="
+          "range": "bytes=0-701",
+          "checksum": "sha1-AgNpIM5kbqhExgj1V/7yLHFIqCM="
         },
         "control": {
-          "range": "bytes=705-1076",
-          "checksum": "sha1-PssMPijjO5cb/9HPMy2kIIsMeRg="
+          "range": "bytes=702-1073",
+          "checksum": "sha1-N17l7rovx6ZyvWjPig+vUTwiF1o="
         },
         "data": {
-          "range": "bytes=1077-5890781",
-          "checksum": "sha256-xOCbEaNh4HPDITw5MTCS41dcqiEwkFhDqrTbkxmVqio="
+          "range": "bytes=1074-5890837",
+          "checksum": "sha256-DdAXTcM5QE5QDyryfYch5RZo7YhmIwwIqik2HEdNzQk="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-Ke9S2HaFpS7a4YuWfI8Vdfw9bAE="
+          "range": "bytes=0-692",
+          "checksum": "sha1-vag+oVK0VVn17klfUbV/LPvkrBo="
         },
         "control": {
-          "range": "bytes=704-1076",
-          "checksum": "sha1-ZxNrny0+ZDgPHFBxhfDrZvjYKx8="
+          "range": "bytes=693-1064",
+          "checksum": "sha1-z+J46RrN0UCtAewvSlFUmF04xbk="
         },
         "data": {
-          "range": "bytes=1077-1135349",
-          "checksum": "sha256-NmZhgcI0Nlkvnl9wtPZsdYZpKC3bOzN2J4g2ZCEocs8="
+          "range": "bytes=1065-1135409",
+          "checksum": "sha256-H9qcekYdSSO9aWUiSUhs3L9f8UonoBKnwUWxGr627PU="
         }
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3-r2.apk",
-        "version": "1.3-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3-r3.apk",
+        "version": "1.3-r3",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-lx9f02YRdXv0hv7FriyHxBeecVw="
+          "range": "bytes=0-706",
+          "checksum": "sha1-LGwktOmKxTxQ3aj4LLAMUxMX7ps="
         },
         "control": {
-          "range": "bytes=701-1082",
-          "checksum": "sha1-DCU2NY6Rs8MpfdUYVgFQ++IK+qg="
+          "range": "bytes=707-1089",
+          "checksum": "sha1-n8lVZkUa7ZAAhwBk/6QfoRJxYkw="
         },
         "data": {
-          "range": "bytes=1083-156557",
-          "checksum": "sha256-bQFWa8+q+iPbve7WnlPoFKT0tc5vxbkJUkF/WEj8C+M="
+          "range": "bytes=1090-156621",
+          "checksum": "sha256-/5V+KbN5lEKru8Fnl6/YqY15M7Bc/Nht1JoJTRB6vWM="
         }
       },
       {
         "name": "apk-tools",
-        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.0-r0.apk",
-        "version": "2.14.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.0-r1.apk",
+        "version": "2.14.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-657",
-          "checksum": "sha1-ymoiwR/HGgPI6Dz5a/1Zh6fha7Q="
+          "range": "bytes=0-694",
+          "checksum": "sha1-2Tr4WKmNRkReEiE9t6oYVlLOObc="
         },
         "control": {
-          "range": "bytes=658-1094",
-          "checksum": "sha1-5lEO4JohyDLUB0MMSqVgQor2Ug8="
+          "range": "bytes=695-1129",
+          "checksum": "sha1-tAzgssIL2RJqyVOp2MQtveTncL8="
         },
         "data": {
-          "range": "bytes=1095-454723",
-          "checksum": "sha256-LJsAe8zTp0gXfPprwAs0lqnUjhG2t4ytWAQZajDu81w="
+          "range": "bytes=1130-499979",
+          "checksum": "sha256-Hn/2H01tfNGkBeFum2PRzjxt1mBYpRvHpp9PNNawhnY="
         }
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-x1MdJ+zveYiBpI0dOT+jhRvF+4g="
+          "range": "bytes=0-690",
+          "checksum": "sha1-v9Q9RQOhzDYV7inN1BoXuUP3l4w="
         },
         "control": {
-          "range": "bytes=704-1094",
-          "checksum": "sha1-FfEelnNTmSQEFGZPgTTjebuQc8M="
+          "range": "bytes=691-1081",
+          "checksum": "sha1-dATsPKHWTsb0iDIEMjwfAKEbnFg="
         },
         "data": {
-          "range": "bytes=1095-74699",
-          "checksum": "sha256-F5X+REDiSp7sVaeoifQDbP75IFgus+1HWA6jBDjva1Y="
+          "range": "bytes=1082-74757",
+          "checksum": "sha256-uLEJdJN7gmOddnhxV/zLbWpo443A14A0Y3MAVkrauEs="
         }
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.36.1-r2.apk",
-        "version": "1.36.1-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.36.1-r4.apk",
+        "version": "1.36.1-r4",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-660",
-          "checksum": "sha1-j8OEvqjvBe2INGxLIH/TkRi3c2Q="
+          "range": "bytes=0-705",
+          "checksum": "sha1-5NCgJNnsVbBpQqLgNDCUeTuCJH4="
         },
         "control": {
-          "range": "bytes=661-1153",
-          "checksum": "sha1-d2kYe9D3/7EJ+b9C6YkKqlSsU/M="
+          "range": "bytes=706-1201",
+          "checksum": "sha1-wVRlDOh92h7dha3wjN6qk482CNg="
         },
         "data": {
-          "range": "bytes=1154-668762",
-          "checksum": "sha256-/ZVBynpsT9iBHekkLAf59csVhMBwoKyjLnjF53u2cIE="
+          "range": "bytes=1202-668820",
+          "checksum": "sha256-wuVIQy+e5s9siVpvdXfddUihG18+Yt3JaH2tfs5HvgI="
         }
       },
       {

--- a/examples/wolfi-base/apko.resolved.json
+++ b/examples/wolfi-base/apko.resolved.json
@@ -22,218 +22,218 @@
     "packages": [
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20230506-r0.apk",
-        "version": "20230506-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20230506-r1.apk",
+        "version": "20230506-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-649",
-          "checksum": "sha1-HoqYVacxp/KTeMmeQyrXh6Mqa0w="
+          "range": "bytes=0-696",
+          "checksum": "sha1-8R2wh98RRnJXoDSksgIT/89AkLc="
         },
         "control": {
-          "range": "bytes=650-966",
-          "checksum": "sha1-/YGo3iUSdyF2/rk3tKR6MhtUEzg="
+          "range": "bytes=697-1030",
+          "checksum": "sha1-/kLPUjePSMngiqVtUCW4RJ4E2ts="
         },
         "data": {
-          "range": "bytes=967-249591",
-          "checksum": "sha256-7neBVl819zb1HiRNaW8Ze6E1SPTrvfxytQyCdRTbUrg="
+          "range": "bytes=1031-249633",
+          "checksum": "sha256-G7/jlC0ypBZIx+QAMUa5z/B3p+tm4Itz04emyjG9gFw="
         }
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r6.apk",
-        "version": "20230201-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r7.apk",
+        "version": "20230201-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-B0aZFr+bN3sKl78a/r6g1idipu8="
+          "range": "bytes=0-701",
+          "checksum": "sha1-1CcRiULOFhX8ldA/Ae2qCMUGNmQ="
         },
         "control": {
-          "range": "bytes=701-1049",
-          "checksum": "sha1-7VhAhkjHFu8hi9j6VPHxlOX95sc="
+          "range": "bytes=702-1052",
+          "checksum": "sha1-OHhyuiUviNHTg939DA0lyeRee18="
         },
         "data": {
-          "range": "bytes=1050-125391",
-          "checksum": "sha256-E1YOC4cEwiNxueSte+3mQzPSxBGuAE7D89R3E7gVxYQ="
+          "range": "bytes=1053-125427",
+          "checksum": "sha256-om3EZzEM+3dD9a77sOB2uOuAKBlf7XoUW/ORnDHQvZY="
         }
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-702",
-          "checksum": "sha1-Twc8OsnLpiLGr1glsxwizLwFm6w="
+          "range": "bytes=0-697",
+          "checksum": "sha1-IL3B1HZ2wdNyCOBXYFZGcbBGoqs="
         },
         "control": {
-          "range": "bytes=703-1098",
-          "checksum": "sha1-yRtxTKuHnEGufUD0mlqieHDebDQ="
+          "range": "bytes=698-1093",
+          "checksum": "sha1-fN6EOYCDfkAB0hPHFXGOflxx/io="
         },
         "data": {
-          "range": "bytes=1099-266150",
-          "checksum": "sha256-6iPIpa/6dq+RZoFex1CmoSSaI6mEN6d8cv4l0YfqiC8="
+          "range": "bytes=1094-266208",
+          "checksum": "sha256-EMs+i+Ylu+q91xSbRNeqlqVgqO0WCIY559NT30Stx7U="
         }
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-699",
-          "checksum": "sha1-ySFnkUiQl1nB8rfphClg+mWZCSk="
+          "checksum": "sha1-TgYN2N4ZPQ7UX0v1ZIi/AM8b6AA="
         },
         "control": {
-          "range": "bytes=700-1044",
-          "checksum": "sha1-yRCBPlJijvUTQJpBTWP+MHT2D8A="
+          "range": "bytes=700-1043",
+          "checksum": "sha1-QTmeDpnOOVYHZq8AeVfdK7DSxsE="
         },
         "data": {
-          "range": "bytes=1045-416966",
-          "checksum": "sha256-SYFhAsz3YuZICPwI7wN3IcQTd/xSH/ByYzzqmurK0Js="
+          "range": "bytes=1044-417005",
+          "checksum": "sha256-On9nfE5oODRF1N//C4DT+Ksz50Rk+O7vCqixUP59dv8="
         }
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-RfviNP7s2tnz3c3t7uFVXy5pOHY="
+          "range": "bytes=0-700",
+          "checksum": "sha1-8nqEerTDUCfn8WzV0y2I02S/Kz0="
         },
         "control": {
-          "range": "bytes=700-1307",
-          "checksum": "sha1-fSgAC/WGQifn2sDPv25EL73z1h0="
+          "range": "bytes=701-1311",
+          "checksum": "sha1-1DIBkq6kQLwbvpYZebVCaXDf7x0="
         },
         "data": {
-          "range": "bytes=1308-6656588",
-          "checksum": "sha256-n6tptyg9cb6NchzSOEARa2N5AJXkkWiEiXjgH/bZ5Vg="
+          "range": "bytes=1312-6660729",
+          "checksum": "sha256-m56Xq6r3fySpzAh1aTHVfHx1O1u5V4RPysRESTISJGg="
         }
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-697",
-          "checksum": "sha1-VccH1xt76d4q4NqO2DesP8w1rqU="
+          "range": "bytes=0-699",
+          "checksum": "sha1-lV63/Vm/cSQyXxEtH2TLeQsQrJY="
         },
         "control": {
-          "range": "bytes=698-1035",
-          "checksum": "sha1-e+hwE3mYrW9g8yHQu6oqmBRBwOw="
+          "range": "bytes=700-1032",
+          "checksum": "sha1-kYtyci1iQwFlIvuj7S54ofi436Y="
         },
         "data": {
-          "range": "bytes=1036-87933",
-          "checksum": "sha256-XRYVqaGoS9WbL4PiDbIf77Wb/9P09hfh0e79oIpsioM="
+          "range": "bytes=1033-87981",
+          "checksum": "sha256-Jykzhaq1lMhpTWNAowIKrOh01jr11fVd0Ga1mgBhzxs="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-704",
-          "checksum": "sha1-9kQPC2FvQx/v+vSG2DOXwoZEz+M="
+          "range": "bytes=0-701",
+          "checksum": "sha1-AgNpIM5kbqhExgj1V/7yLHFIqCM="
         },
         "control": {
-          "range": "bytes=705-1076",
-          "checksum": "sha1-PssMPijjO5cb/9HPMy2kIIsMeRg="
+          "range": "bytes=702-1073",
+          "checksum": "sha1-N17l7rovx6ZyvWjPig+vUTwiF1o="
         },
         "data": {
-          "range": "bytes=1077-5890781",
-          "checksum": "sha256-xOCbEaNh4HPDITw5MTCS41dcqiEwkFhDqrTbkxmVqio="
+          "range": "bytes=1074-5890837",
+          "checksum": "sha256-DdAXTcM5QE5QDyryfYch5RZo7YhmIwwIqik2HEdNzQk="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-Ke9S2HaFpS7a4YuWfI8Vdfw9bAE="
+          "range": "bytes=0-692",
+          "checksum": "sha1-vag+oVK0VVn17klfUbV/LPvkrBo="
         },
         "control": {
-          "range": "bytes=704-1076",
-          "checksum": "sha1-ZxNrny0+ZDgPHFBxhfDrZvjYKx8="
+          "range": "bytes=693-1064",
+          "checksum": "sha1-z+J46RrN0UCtAewvSlFUmF04xbk="
         },
         "data": {
-          "range": "bytes=1077-1135349",
-          "checksum": "sha256-NmZhgcI0Nlkvnl9wtPZsdYZpKC3bOzN2J4g2ZCEocs8="
+          "range": "bytes=1065-1135409",
+          "checksum": "sha256-H9qcekYdSSO9aWUiSUhs3L9f8UonoBKnwUWxGr627PU="
         }
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3-r2.apk",
-        "version": "1.3-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3-r3.apk",
+        "version": "1.3-r3",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-lx9f02YRdXv0hv7FriyHxBeecVw="
+          "range": "bytes=0-706",
+          "checksum": "sha1-LGwktOmKxTxQ3aj4LLAMUxMX7ps="
         },
         "control": {
-          "range": "bytes=701-1082",
-          "checksum": "sha1-DCU2NY6Rs8MpfdUYVgFQ++IK+qg="
+          "range": "bytes=707-1089",
+          "checksum": "sha1-n8lVZkUa7ZAAhwBk/6QfoRJxYkw="
         },
         "data": {
-          "range": "bytes=1083-156557",
-          "checksum": "sha256-bQFWa8+q+iPbve7WnlPoFKT0tc5vxbkJUkF/WEj8C+M="
+          "range": "bytes=1090-156621",
+          "checksum": "sha256-/5V+KbN5lEKru8Fnl6/YqY15M7Bc/Nht1JoJTRB6vWM="
         }
       },
       {
         "name": "apk-tools",
-        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.0-r0.apk",
-        "version": "2.14.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.0-r1.apk",
+        "version": "2.14.0-r1",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-657",
-          "checksum": "sha1-ymoiwR/HGgPI6Dz5a/1Zh6fha7Q="
+          "range": "bytes=0-694",
+          "checksum": "sha1-2Tr4WKmNRkReEiE9t6oYVlLOObc="
         },
         "control": {
-          "range": "bytes=658-1094",
-          "checksum": "sha1-5lEO4JohyDLUB0MMSqVgQor2Ug8="
+          "range": "bytes=695-1129",
+          "checksum": "sha1-tAzgssIL2RJqyVOp2MQtveTncL8="
         },
         "data": {
-          "range": "bytes=1095-454723",
-          "checksum": "sha256-LJsAe8zTp0gXfPprwAs0lqnUjhG2t4ytWAQZajDu81w="
+          "range": "bytes=1130-499979",
+          "checksum": "sha256-Hn/2H01tfNGkBeFum2PRzjxt1mBYpRvHpp9PNNawhnY="
         }
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-x1MdJ+zveYiBpI0dOT+jhRvF+4g="
+          "range": "bytes=0-690",
+          "checksum": "sha1-v9Q9RQOhzDYV7inN1BoXuUP3l4w="
         },
         "control": {
-          "range": "bytes=704-1094",
-          "checksum": "sha1-FfEelnNTmSQEFGZPgTTjebuQc8M="
+          "range": "bytes=691-1081",
+          "checksum": "sha1-dATsPKHWTsb0iDIEMjwfAKEbnFg="
         },
         "data": {
-          "range": "bytes=1095-74699",
-          "checksum": "sha256-F5X+REDiSp7sVaeoifQDbP75IFgus+1HWA6jBDjva1Y="
+          "range": "bytes=1082-74757",
+          "checksum": "sha256-uLEJdJN7gmOddnhxV/zLbWpo443A14A0Y3MAVkrauEs="
         }
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.36.1-r2.apk",
-        "version": "1.36.1-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.36.1-r4.apk",
+        "version": "1.36.1-r4",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-660",
-          "checksum": "sha1-j8OEvqjvBe2INGxLIH/TkRi3c2Q="
+          "range": "bytes=0-705",
+          "checksum": "sha1-5NCgJNnsVbBpQqLgNDCUeTuCJH4="
         },
         "control": {
-          "range": "bytes=661-1153",
-          "checksum": "sha1-d2kYe9D3/7EJ+b9C6YkKqlSsU/M="
+          "range": "bytes=706-1201",
+          "checksum": "sha1-wVRlDOh92h7dha3wjN6qk482CNg="
         },
         "data": {
-          "range": "bytes=1154-668762",
-          "checksum": "sha256-/ZVBynpsT9iBHekkLAf59csVhMBwoKyjLnjF53u2cIE="
+          "range": "bytes=1202-668820",
+          "checksum": "sha256-wuVIQy+e5s9siVpvdXfddUihG18+Yt3JaH2tfs5HvgI="
         }
       },
       {
@@ -274,218 +274,218 @@
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20230506-r0.apk",
-        "version": "20230506-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20230506-r1.apk",
+        "version": "20230506-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-647",
-          "checksum": "sha1-s9/tr3z/dZPicv1OVKz31ysaJQE="
+          "range": "bytes=0-700",
+          "checksum": "sha1-aUXTrOGFmIjd0x+HLCRZvR2X1a0="
         },
         "control": {
-          "range": "bytes=648-935",
-          "checksum": "sha1-N1RG8Ckcg5B0Nlp6kS26dA5WFwY="
+          "range": "bytes=701-1033",
+          "checksum": "sha1-gMuh2d1dY1EY0Ganu9Ls/RRIXUI="
         },
         "data": {
-          "range": "bytes=936-249592",
-          "checksum": "sha256-JounDEIr83QfxnDYPBhlTQylRA7HgcBlgABrHYkIyMk="
+          "range": "bytes=1034-249634",
+          "checksum": "sha256-PpXQiz31ojbE87mPgRa6+ChldVHRHk8HGOUsR1wL44g="
         }
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r6.apk",
-        "version": "20230201-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r7.apk",
+        "version": "20230201-r7",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-698",
-          "checksum": "sha1-7pyg3ZZyuqiKYxS+nOTx8KoRV+8="
+          "checksum": "sha1-PRg1PDX7kg66RMuAOkXYZ4IDJ9I="
         },
         "control": {
           "range": "bytes=699-1046",
-          "checksum": "sha1-1IRhQ5Af8EsskNGI41B61PJKEmQ="
+          "checksum": "sha1-/4xGSMRg+0rCwuLMLe6Yi8k3BSE="
         },
         "data": {
-          "range": "bytes=1047-125392",
-          "checksum": "sha256-8ugMC+WWnVs2LDEgnIjgFy489tBWgjsJGRnK85brHok="
+          "range": "bytes=1047-125428",
+          "checksum": "sha256-r9K9i+RMG6uUWY7L/TrqkZdyNHoU3PnhSez4++ItCiA="
         }
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-bc/LYdjt1YRKBVqFo0OCWrLDsW4="
+          "range": "bytes=0-708",
+          "checksum": "sha1-u0ApCBiurwCwBzVLWXLBOjPWiww="
         },
         "control": {
-          "range": "bytes=701-1095",
-          "checksum": "sha1-VOuDI6cngPUe0QMmQTSmAsD6cEY="
+          "range": "bytes=709-1102",
+          "checksum": "sha1-tQL1lJCaj9X6qz0Zfl/wpT0WAKE="
         },
         "data": {
-          "range": "bytes=1096-265291",
-          "checksum": "sha256-kY0/ezJ2DVrUT2X/oRrXuoiUzfGIXtn3E2owX3JckmQ="
+          "range": "bytes=1103-265349",
+          "checksum": "sha256-hHfanGAvtlWTL40t2AO0N7kAD7xlNfDLcEfPm3/DnZo="
         }
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-705",
-          "checksum": "sha1-H6DEtQIVLnNrXc0r+DcUglYx4Q0="
+          "range": "bytes=0-697",
+          "checksum": "sha1-4+Mp2flaIYKiEJ6XKwtoBTgDjCU="
         },
         "control": {
-          "range": "bytes=706-1048",
-          "checksum": "sha1-PVoyenqq3cd0c4fNbErXj3Fma/U="
+          "range": "bytes=698-1040",
+          "checksum": "sha1-XHNKylXG1NelDm64u3IBf9IVjX0="
         },
         "data": {
-          "range": "bytes=1049-416967",
-          "checksum": "sha256-q5DBf/WP90hZEKQPr6WXvmZHWaXzRRrFdVsToSR/a7g="
+          "range": "bytes=1041-417006",
+          "checksum": "sha256-miBw1ZOB261zgoVG81Yhdf5L1xmWYYV3p6dNAHSxERA="
         }
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.38-r6.apk",
-        "version": "2.38-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-R8Wr6MgRmGcNHhEi+fouU7SuLtQ="
+          "range": "bytes=0-701",
+          "checksum": "sha1-Vc9khIZZTafVjDK78luP9JX6x8g="
         },
         "control": {
-          "range": "bytes=700-1304",
-          "checksum": "sha1-CnMimmBZKU82tMyI5H26UMN6l4I="
+          "range": "bytes=702-1308",
+          "checksum": "sha1-8D31WR0R9iF0kHeeJpZI1AKgagQ="
         },
         "data": {
-          "range": "bytes=1305-5592270",
-          "checksum": "sha256-+eWbn5IaCaRs8lB21Pzlfeefho7eb4pIDKMW/6fJMxs="
+          "range": "bytes=1309-5592315",
+          "checksum": "sha256-57srttgz2wBUOpUmzVeHnaPlPqib97l1cziHW08ulIA="
         }
       },
       {
         "name": "openssl-config",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssl-config-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-5W7sPjc8XkeOKSkJFYlP8xQQx2s="
+          "range": "bytes=0-700",
+          "checksum": "sha1-p1qaSIYhdFoYjVL7SHjou2SPZYU="
         },
         "control": {
-          "range": "bytes=700-1034",
-          "checksum": "sha1-MxQCyBxrYF9/SQtwuug2IxAag2s="
+          "range": "bytes=701-1033",
+          "checksum": "sha1-7O37tZQFOQvSgQ2mCWEJ0EcbC6o="
         },
         "data": {
-          "range": "bytes=1035-87934",
-          "checksum": "sha256-vNVrzURfLpgh3TYwvri0YaN1f9uP8OOOtu+C3A5r/MQ="
+          "range": "bytes=1034-87982",
+          "checksum": "sha256-J/gaoFoW6EbTdvEO4NzAHfl4dPqEVRl0i3W62+XEJN4="
         }
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-703",
-          "checksum": "sha1-1LnbG68ebL7Bhee1iapnp2+LGGk="
+          "range": "bytes=0-706",
+          "checksum": "sha1-OIq+JiPfrRM75nzGi29NwzRqSbk="
         },
         "control": {
-          "range": "bytes=704-1089",
-          "checksum": "sha1-dtZ1Z+s47m2J5hepxlMVRGK/FT4="
+          "range": "bytes=707-1092",
+          "checksum": "sha1-KzSsaxXiKaJ1PEuVfmb/xZttOoA="
         },
         "data": {
-          "range": "bytes=1090-4972734",
-          "checksum": "sha256-vmMyFpheu/oj38dqxi1HaVlYyPuKnrNlgpDrCVT3jIs="
+          "range": "bytes=1093-4972790",
+          "checksum": "sha256-mYxenlqkXj1psWRZQs0+u8qtwf46GM/5oUNtdCuRd4U="
         }
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.2.0-r0.apk",
-        "version": "3.2.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.2.0-r1.apk",
+        "version": "3.2.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-wV6Qk7pvBx1g0AOukyOt4FHPF4I="
+          "range": "bytes=0-705",
+          "checksum": "sha1-Wk5j5JDG1mI0+l1OiEdKW/HL4T0="
         },
         "control": {
-          "range": "bytes=700-1081",
-          "checksum": "sha1-ZMt0V0SnkCxZ+rVwbyO3b3YP9vM="
+          "range": "bytes=706-1086",
+          "checksum": "sha1-btRuPg8wQIjjOYzRxdp45Z0INuk="
         },
         "data": {
-          "range": "bytes=1082-1130998",
-          "checksum": "sha256-3z7sOXBIFsYA4YTkLFKg0uqvkOamr6f2lrucNUU+N5Y="
+          "range": "bytes=1087-1131058",
+          "checksum": "sha256-f1/PimvUP+YCCwo6Mr6cahHK8jLaWeGnw0dTCSKvt5c="
         }
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3-r2.apk",
-        "version": "1.3-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3-r3.apk",
+        "version": "1.3-r3",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-700",
-          "checksum": "sha1-1S276hPYl+9ssemIoJG7TYGfAMM="
+          "range": "bytes=0-691",
+          "checksum": "sha1-5E6pZh0EM0DyOIx7NwtvlArOW0c="
         },
         "control": {
-          "range": "bytes=701-1095",
-          "checksum": "sha1-WYRIXWM96qWE1c0WhV4TM+qSTko="
+          "range": "bytes=692-1086",
+          "checksum": "sha1-YiAx3eMWhOxqleVmn3gM0olZEKQ="
         },
         "data": {
-          "range": "bytes=1096-191254",
-          "checksum": "sha256-i4AaBbeXFdD3FXVsbKC6T9SmUXIrDGkn/wbj+9PX8Lo="
+          "range": "bytes=1087-191318",
+          "checksum": "sha256-9Du3QlZ09zDdfsS3HxJSvLVIffQXKHuwH6Opl971gZs="
         }
       },
       {
         "name": "apk-tools",
-        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.0-r0.apk",
-        "version": "2.14.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.0-r1.apk",
+        "version": "2.14.0-r1",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-657",
-          "checksum": "sha1-/pRAL96gP1XHx1k+tRsJZcjl0ec="
+          "range": "bytes=0-700",
+          "checksum": "sha1-8vhyOfegR0P/yaMBcp7+dBGjagM="
         },
         "control": {
-          "range": "bytes=658-1090",
-          "checksum": "sha1-I3OAi6ke9HMmxkiab+4MuJQmdUQ="
+          "range": "bytes=701-1129",
+          "checksum": "sha1-JFLblNleo+XoRzgGSDd6QMUuzSM="
         },
         "data": {
-          "range": "bytes=1091-552340",
-          "checksum": "sha256-VH73KhNt/1S0ukNpkqJq6f73nHK06O7MsAwsZFlUglI="
+          "range": "bytes=1130-605132",
+          "checksum": "sha256-LRI/KNPIkknYLPT4+NK8mIRlB+OVKwc9MbHvoJHuPpc="
         }
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.38-r5.apk",
-        "version": "2.38-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.38-r8.apk",
+        "version": "2.38-r8",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-694",
-          "checksum": "sha1-iDrfPe5FhU3bHhxbaAZ3qyxQTrY="
+          "checksum": "sha1-NwjywwWpfq7FwKm3ZP7jLf/VumQ="
         },
         "control": {
-          "range": "bytes=695-1082",
-          "checksum": "sha1-aSYR0I4tmd4gEFAXxOMSezg18GI="
+          "range": "bytes=695-1081",
+          "checksum": "sha1-0O4IuDHa+IvhWX62aW2Uj0SWyBo="
         },
         "data": {
-          "range": "bytes=1083-101348",
-          "checksum": "sha256-QI8ZnzVe4Hw3niiRdbL9u+aBuDMD+cA5Q0Z6Z3TSAmc="
+          "range": "bytes=1082-101406",
+          "checksum": "sha256-RgeVQFodY5IzTg18nwE9iFAdtNxy9x2qNrNN0SWZ7ks="
         }
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.36.1-r2.apk",
-        "version": "1.36.1-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.36.1-r4.apk",
+        "version": "1.36.1-r4",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-m9X6KDEy74aCpQlKlkegUn5XjOo="
+          "range": "bytes=0-705",
+          "checksum": "sha1-hnv8ydWc0uIHiB1vw/BN+XFYUQY="
         },
         "control": {
-          "range": "bytes=663-1148",
-          "checksum": "sha1-seigbSQse4Xfe9+fcu4mQlROELc="
+          "range": "bytes=706-1196",
+          "checksum": "sha1-NaRv5Dd4ywo+HKbaxeqWrqlSyIw="
         },
         "data": {
-          "range": "bytes=1149-738253",
-          "checksum": "sha256-OAfCAR9diQsN/NifKaGSUalgVuRMlk5Q5QIm/Es0Dy0="
+          "range": "bytes=1197-738309",
+          "checksum": "sha256-06U+CLm2QRJglmzaFbXwLxcruJcPyZuiTsEESjlBLQU="
         }
       },
       {


### PR DESCRIPTION
Currently when signature part of package changes, it triggers immediate failure of the build process 
(especially when the lock-file is used). 

Here we prefer to use the predefined hash to fetch the artifact (for perfomance  reasons) and to have the warning printed if the SHAs does not match -> but still allow the build process to proceeed.