### PR TITLE
pass correct apko binary runfiles path to apko_run launcher

### DIFF
--- a/apko/private/apko_run.bzl
+++ b/apko/private/apko_run.bzl
@@ -36,7 +36,7 @@ def _impl(ctx):
     ctx.actions.write(
         output = output,
         content = LAUNCHER_TEMPLATE
-            .replace("{{apko_binary}}", apko_info.binary.path)
+            .replace("{{apko_binary}}", apko_info.binary.short_path)
             .replace("{{workdir_env}}", "BUILD_" + ctx.attr.workdir.upper() + "_DIRECTORY"),
         is_executable = True,
     )

--- a/apko/private/apko_run.bzl
+++ b/apko/private/apko_run.bzl
@@ -1,4 +1,4 @@
-"A rule for running apko - convenience layer to stay within consistent versions."
+"A rule for running apko - convenience layer to stay within consisten versions and use bazel cache."
 
 _WORKDIR_DOC = """
   The dir where apko will get executed:


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph, we've [defined our own apko toolchain](https://github.com/sourcegraph/sourcegraph/pull/60785/files#diff-7fc57714ef13c3325ce2a1130202edced92fcccc0c6db34a72f7b57f60d552a3R350-R356) to integrate a patch to [go-apk](https://github.com/chainguard-dev/go-apk/pull/216) for the apko binary. Due to this, we pass `register = False` to `apko_register_toolchains`. 

This surfaced a correctness issue when trying to run `bazel run @rules_apko//apko`, with the following error:
```
INFO: Running command line: bazel-bin/external/rules_apko/apko/_apko_run.sh
Workdir: /home/noah/Sourcegraph/sourcegraph
/home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/execroot/__main__/bazel-out/k8-fastbuild/bin/external/rules_apko/apko/_apko_run.sh: line 11: /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/execroot/__main__/bazel-out/k8-fastbuild/bin/external/rules_apko/apko/_apko_run.sh.runfiles/__main__/bazel-out/k8-opt-exec-ST-13d3ddad9198/bin/external/dev_chainguard_apko/apko_/apko: No such file or directory
```

From [the bazel docs on runfiles location](https://bazel.build/extending/rules#runfiles_location), this particular quote highlights the correct way to build the path to the apko binary's runfile path: "The path to a File under the runfiles directory corresponds to [File.short_path](https://bazel.build/rules/lib/builtins/File#short_path)."

The change presented works both for our case, and also `bazel run //apko:apko` in the rules_apko repo :slightly_smiling_face: 