### PR TITLE
Make `.lock` rule work when passing `config` to `apko_image` as label to generated target.

### DIFF
--- a/apko/private/apko_image.bzl
+++ b/apko/private/apko_image.bzl
@@ -153,7 +153,8 @@ def apko_image(name, contents, config, tag, output = "oci", architecture = None,
         for _ in native.glob([lock_json_name]):
             apko_run(
                 name = name + ".lock",
-                args = ["lock", "$(execpath {})".format(config), "--output={}".format(lock_json_name)],
+                # args is subject to make variables substitution: https://bazel.build/reference/be/common-definitions#common-attributes-binaries
+                args = ["lock", "$(execpath {})".format(config), "--output={}/{}".format(config_label.package, lock_json_name)],
                 workdir = "workspace",
                 data = [config],
             )
@@ -164,7 +165,8 @@ def apko_image(name, contents, config, tag, output = "oci", architecture = None,
         for _ in native.glob([resolved_json_name]):
             apko_run(
                 name = name + ".resolve",
-                args = ["resolve", "$(execpath {})".format(config), "--output={}".format(lock_json_name)],
+                # args is subject to make variables substitution: https://bazel.build/reference/be/common-definitions#common-attributes-binaries
+                args = ["resolve", "$(execpath {})".format(config), "--output={}/{}".format(config_label.package, lock_json_name)],
                 workdir = "workspace",
                 data = [config],
                 deprecated = "Please use .lock target instead. Rename your .resolve.json file to .lock.json file.",

--- a/apko/private/apko_image.bzl
+++ b/apko/private/apko_image.bzl
@@ -153,8 +153,9 @@ def apko_image(name, contents, config, tag, output = "oci", architecture = None,
         for _ in native.glob([lock_json_name]):
             apko_run(
                 name = name + ".lock",
-                args = ["lock", config_label.package + "/" + config_label.name],
+                args = ["lock", "$(location {})".format(config), "--output={}".format(lock_json_name)],
                 workdir = "workspace",
+                data = [config],
             )
 
         resolved_json_name = config_label.name.removesuffix(".yaml") + ".resolved.json"
@@ -163,7 +164,8 @@ def apko_image(name, contents, config, tag, output = "oci", architecture = None,
         for _ in native.glob([resolved_json_name]):
             apko_run(
                 name = name + ".resolve",
-                args = ["resolve", config_label.package + "/" + config_label.name],
+                args = ["resolve", "$(location {})".format(config), "--output={}".format(lock_json_name)],
                 workdir = "workspace",
+                data = [config],
                 deprecated = "Please use .lock target instead. Rename your .resolve.json file to .lock.json file.",
             )

--- a/apko/private/apko_image.bzl
+++ b/apko/private/apko_image.bzl
@@ -153,7 +153,7 @@ def apko_image(name, contents, config, tag, output = "oci", architecture = None,
         for _ in native.glob([lock_json_name]):
             apko_run(
                 name = name + ".lock",
-                args = ["lock", "$(location {})".format(config), "--output={}".format(lock_json_name)],
+                args = ["lock", "$(execpath {})".format(config), "--output={}".format(lock_json_name)],
                 workdir = "workspace",
                 data = [config],
             )
@@ -164,7 +164,7 @@ def apko_image(name, contents, config, tag, output = "oci", architecture = None,
         for _ in native.glob([resolved_json_name]):
             apko_run(
                 name = name + ".resolve",
-                args = ["resolve", "$(location {})".format(config), "--output={}".format(lock_json_name)],
+                args = ["resolve", "$(execpath {})".format(config), "--output={}".format(lock_json_name)],
                 workdir = "workspace",
                 data = [config],
                 deprecated = "Please use .lock target instead. Rename your .resolve.json file to .lock.json file.",

--- a/apko/private/apko_run.bzl
+++ b/apko/private/apko_run.bzl
@@ -5,8 +5,13 @@ _WORKDIR_DOC = """
     - working - the dir where bazel was called.
     - workspace - the root directory of the bazel workspace (usually repository root)"""
 
+_DATA_DOC = """
+  Any files that will be used for the apko run
+"""
+
 _ATTRS = {
     "workdir": attr.string(default = "working", doc = _WORKDIR_DOC, mandatory = False, values = ["working", "workspace"]),
+    "data": attr.label_list(allow_files = True, doc = _DATA_DOC),
 }
 
 _DOC = """

--- a/apko/private/apko_run.bzl
+++ b/apko/private/apko_run.bzl
@@ -46,7 +46,13 @@ def _impl(ctx):
         is_executable = True,
     )
 
-    return DefaultInfo(executable = output, runfiles = ctx.runfiles(files = [apko_info.binary]))
+    return DefaultInfo(
+        executable = output,
+        files = depset(ctx.files.data),
+        runfiles = ctx.runfiles(
+            files = [apko_info.binary],
+        ),
+    )
 
 apko_run_lib = struct(
     attrs = _ATTRS,

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -2,12 +2,13 @@
 
 load("@rules_apko//apko:defs.bzl", "apko_bazelrc", "apko_image")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 apko_bazelrc()
 
 apko_image(
     name = "lock",
-    config = "apko.yaml",
+    config = ":apko.yaml",
     contents = "@example_lock//:contents",
     tag = "lock:latest",
 )
@@ -17,4 +18,17 @@ build_test(
     targets = [
         ":lock",
     ],
+)
+
+copy_file(
+    name = "generated_config",
+    src = ":apko.yaml",
+    out = "apko.generated.yaml",
+)
+
+apko_image(
+    name = "lock_from_generated",
+    config = ":apko.generated.yaml",
+    contents = "@example_lock//:contents",
+    tag = "lock:latest",
 )

--- a/e2e/smoke/apko.generated.lock.json
+++ b/e2e/smoke/apko.generated.lock.json
@@ -1,0 +1,53 @@
+{
+  "version": "v1",
+  "contents": {
+    "keyring": [],
+    "repositories": [
+      {
+        "name": "dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "musl",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/musl-1.2.4-r2.apk",
+        "version": "1.2.4-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "bytes=0-666",
+          "checksum": "sha1-MiA7YiamUyscxmdGiRBGiJjcW8U="
+        },
+        "control": {
+          "range": "bytes=667-1224",
+          "checksum": "sha1-odtIYtKyOCg6suF/cDaYpygL7hw="
+        },
+        "data": {
+          "range": "bytes=1225-634880",
+          "checksum": "sha256-KPwSgRdeAcnVvczowX1F54Aszov9ZI1cRXgtFZzepfg="
+        },
+        "checksum": "Q1odtIYtKyOCg6suF/cDaYpygL7hw="
+      },
+      {
+        "name": "busybox",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r5.apk",
+        "version": "1.36.1-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "bytes=0-665",
+          "checksum": "sha1-oXF25kDE6Jja1iQ2psyt9nV+ddE="
+        },
+        "control": {
+          "range": "bytes=666-2301",
+          "checksum": "sha1-aBWv1Kn2ASOLShUeDPoSLaozuMs="
+        },
+        "data": {
+          "range": "bytes=2302-946176",
+          "checksum": "sha256-pDdzepugl8LYISmpJ2wGr885gfpwo2hi9ZMf4dQTi5s="
+        },
+        "checksum": "Q1aBWv1Kn2ASOLShUeDPoSLaozuMs="
+      }
+    ]
+  }
+}

--- a/examples/multi_arch_and_repo/apko.lock.json
+++ b/examples/multi_arch_and_repo/apko.lock.json
@@ -103,22 +103,22 @@
       },
       {
         "name": "ca-certificates",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/ca-certificates-20230506-r0.apk",
-        "version": "20230506-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/ca-certificates-20240226-r0.apk",
+        "version": "20240226-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-664",
-          "checksum": "sha1-fIz32qJcugmhmKKw9Qt4jPWsNIg="
+          "checksum": "sha1-RVDdklAq+Ma3ZvVuvwP+QeDA5yU="
         },
         "control": {
-          "range": "bytes=665-1570",
-          "checksum": "sha1-ueh9A7UhwfUJqrKqr4NB+tlPtrE="
+          "range": "bytes=665-1546",
+          "checksum": "sha1-8fyhRCTYUIwWsLgkTyfJObgzhuU="
         },
         "data": {
-          "range": "bytes=1571-811008",
-          "checksum": "sha256-WeOxiGqnwsMP4Zq0wgMlRNXFqRp9j8nnV1CsLioEggg="
+          "range": "bytes=1547-835584",
+          "checksum": "sha256-GDwlC6BAQo7f2Crf3a/yuZKPXpMu4jr804wBa9uR89k="
         },
-        "checksum": "Q1ueh9A7UhwfUJqrKqr4NB+tlPtrE="
+        "checksum": "Q18fyhRCTYUIwWsLgkTyfJObgzhuU="
       },
       {
         "name": "libmagic",
@@ -445,22 +445,22 @@
       },
       {
         "name": "libexpat",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libexpat-2.6.0-r0.apk",
-        "version": "2.6.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/libexpat-2.6.2-r0.apk",
+        "version": "2.6.2-r0",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-663",
-          "checksum": "sha1-sOUsr/dCyi/DbhpUVyCu3ejzx/c="
+          "range": "bytes=0-665",
+          "checksum": "sha1-3SLONu6xXGXASe5BnVjXdUYyYCs="
         },
         "control": {
-          "range": "bytes=664-1221",
-          "checksum": "sha1-SKqHtyX53V+uZGEdUl76Ha0RM2A="
+          "range": "bytes=666-1221",
+          "checksum": "sha1-XHw11LZClKXK9t5cy44/mdC5rwE="
         },
         "data": {
           "range": "bytes=1222-212992",
-          "checksum": "sha256-kQLTAIXDoQU+ywboe++4B0ww8RS9GT3tTLcCuWMNNAw="
+          "checksum": "sha256-JdeixfA7rjZTaekXrjeKnDPAbUqGfm2oe8jWYOKOdaA="
         },
-        "checksum": "Q1SKqHtyX53V+uZGEdUl76Ha0RM2A="
+        "checksum": "Q1XHw11LZClKXK9t5cy44/mdC5rwE="
       },
       {
         "name": "pcre2",
@@ -882,22 +882,22 @@
       },
       {
         "name": "ca-certificates",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/ca-certificates-20230506-r0.apk",
-        "version": "20230506-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/ca-certificates-20240226-r0.apk",
+        "version": "20240226-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-5UkuWVygPgpCoaxEzz8EXPtDMEw="
+          "range": "bytes=0-664",
+          "checksum": "sha1-U6YuV7cz4yMHc+j1NYeWoyecYQc="
         },
         "control": {
-          "range": "bytes=666-1574",
-          "checksum": "sha1-FG8M+7w+dkjV9Vy0mGFWW2t4+Do="
+          "range": "bytes=665-1566",
+          "checksum": "sha1-M2O65DB56Ju1GLmm2hrKvk6s8KU="
         },
         "data": {
-          "range": "bytes=1575-704512",
-          "checksum": "sha256-BJOYfHwliYN95TgrERMUHssqnNtWVji64rk6oBHf+wc="
+          "range": "bytes=1567-729088",
+          "checksum": "sha256-JSPphCMvOKnVgxDxhJfOHToq2ngE2GQQhNBX9AEFPNM="
         },
-        "checksum": "Q1FG8M+7w+dkjV9Vy0mGFWW2t4+Do="
+        "checksum": "Q1M2O65DB56Ju1GLmm2hrKvk6s8KU="
       },
       {
         "name": "libmagic",
@@ -1224,22 +1224,22 @@
       },
       {
         "name": "libexpat",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libexpat-2.6.0-r0.apk",
-        "version": "2.6.0-r0",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/libexpat-2.6.2-r0.apk",
+        "version": "2.6.2-r0",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-666",
-          "checksum": "sha1-UHt5OpG3+DUStuYHgiUlReOM4eM="
+          "range": "bytes=0-662",
+          "checksum": "sha1-A8N7zPGeDNWP8/1TYlSlHeEyNGU="
         },
         "control": {
-          "range": "bytes=667-1242",
-          "checksum": "sha1-RaHjLErkBML3L8/NW8C2jWVnGHM="
+          "range": "bytes=663-1235",
+          "checksum": "sha1-US763iBUKsj18b17tZrA8l6eojc="
         },
         "data": {
-          "range": "bytes=1243-147456",
-          "checksum": "sha256-msJP6uwx8dkUo8hR6ncV3P1a0dsZNbfPuRj9bElSvig="
+          "range": "bytes=1236-147456",
+          "checksum": "sha256-Aar3x/FZoaw/6qXjCaGOWcn2kyATHpx9THdtKvx735k="
         },
-        "checksum": "Q1RaHjLErkBML3L8/NW8C2jWVnGHM="
+        "checksum": "Q1US763iBUKsj18b17tZrA8l6eojc="
       },
       {
         "name": "pcre2",


### PR DESCRIPTION
Before this change, the `apko.yaml` config file of the image had to be in the source code directory.

With this change it can be output of some bazel rule. 

Generated lockfile is still outputted to source code directory.