### PR TITLE
copy lockfile instead of symlinking when translating

### DIFF
--- a/apko/translate_lock.bzl
+++ b/apko/translate_lock.bzl
@@ -64,9 +64,10 @@ APK_KEYRING_TMPL = """\
 def _translate_apko_lock_impl(rctx):
     lock_file = util.parse_lock(rctx.read(rctx.attr.lock))
 
-    # We copy the lockfile (.lock.json) to avoid visibility problems when we reference it from another module.
+    # We copy the lockfile (.lock.json) to avoid visibility problems when we reference it from another module,
+    # and instead of symlinking in order to avoid "missing input file '@@<lock_repo>//:lockfile_copy'" errors.
     lock_file_local = "lockfile_copy"
-    rctx.symlink(rctx.attr.lock, lock_file_local)
+    rctx.file(lock_file_local, rctx.read(rctx.attr.lock))
 
     apks = []
     indexes = []


### PR DESCRIPTION
We started seeing the following errors on all our `apko_image` targets:

```
(10:27:41) ERROR: /mnt/ephemeral/workdir/sourcegraph/sourcegraph/cmd/batcheshelper/BUILD.bazel:78:11: Action cmd/batcheshelper/wolfi_base_apko failed: missing input file '@@batcheshelper_apko_lock//:lockfile_copy'
(10:27:41) ERROR: /mnt/ephemeral/workdir/sourcegraph/sourcegraph/cmd/batcheshelper/BUILD.bazel:78:11: Action cmd/batcheshelper/wolfi_base_apko failed: 1 input file(s) do not exist
```

Patch tested as part of a fix for the issue (briefly) outlined here: https://github.com/sourcegraph/sourcegraph/pull/61877

I'm not sure why we were suddenly seeing that behaviour or where to start looking to debug this (or how to reliably reproduce it anymore)

rules_apko version 1.2.2