### PR TITLE
Fix linux_386 platform at toolchains_repo.bzl

### DIFF
--- a/apko/private/toolchains_repo.bzl
+++ b/apko/private/toolchains_repo.bzl
@@ -32,7 +32,7 @@ PLATFORMS = {
             "@platforms//cpu:aarch64",
         ],
     ),
-    "linux_i386": struct(
+    "linux_386": struct(
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_32",


### PR DESCRIPTION
Fix https://github.com/chainguard-dev/rules_apko/issues/70