### PR TITLE
Allow users to provide the versions of apko binaries not listed in versions.bzl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,8 +49,6 @@ jobs:
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_6
         run: echo "bazelversion=6.3.0" >> $GITHUB_OUTPUT
-      - id: bazel_7_1_2
-        run: echo "bazelversion=7.1.2" >> $GITHUB_OUTPUT
     outputs:
       # Will look like ["<version from .bazelversion>", "x.y.z"]
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,8 @@ jobs:
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_6
         run: echo "bazelversion=6.3.0" >> $GITHUB_OUTPUT
+      - id: bazel_7_1_2
+        run: echo "bazelversion=7.1.2" >> $GITHUB_OUTPUT
     outputs:
       # Will look like ["<version from .bazelversion>", "x.y.z"]
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}

--- a/apko/private/toolchains_repo.bzl
+++ b/apko/private/toolchains_repo.bzl
@@ -75,7 +75,7 @@ toolchain(
             platform = platform,
             name = repository_ctx.attr.name,
             user_repository_name = repository_ctx.attr.user_repository_name,
-            compatible_with = meta.compatible_with,
+            compatible_with = repository_ctx.attr.compatible_with,
         )
 
     # Base BUILD file for this repository
@@ -87,5 +87,6 @@ toolchains_repo = repository_rule(
      which can be registered or selected.""",
     attrs = {
         "user_repository_name": attr.string(doc = "what the user chose for the base name"),
+        "platforms": attr.string_list(default = PLATFORMS.keys()),
     },
 )

--- a/apko/private/toolchains_repo.bzl
+++ b/apko/private/toolchains_repo.bzl
@@ -75,7 +75,7 @@ toolchain(
             platform = platform,
             name = repository_ctx.attr.name,
             user_repository_name = repository_ctx.attr.user_repository_name,
-            compatible_with = repository_ctx.attr.compatible_with,
+            compatible_with = meta.compatible_with,
         )
 
     # Base BUILD file for this repository

--- a/apko/repositories.bzl
+++ b/apko/repositories.bzl
@@ -116,7 +116,12 @@ def apko_register_toolchains(name, apko_version = LATEST_APKO_VERSION, platform_
         register: whether to call through to native.register_toolchains.
             Should be True for WORKSPACE users, but false when used under bzlmod extension
         apko_version: version of apko
-        platform_to_apko_binary_map: specialized way of providing urls of apko binaries for the toolchains. Map of platform string
+        platform_to_apko_binary_map: specialized way of providing urls of apko binaries for the toolchains.
+            If specified, apko_version is ignored. It is a dict of platform string to struct produced by
+            apko_binary_spec macro that consists of url to the archive with apko binary, it's sha256, version
+            of apko and prefix that should be stripped after unpacking the archive. The prefix
+            should specified, so that apko binary lands in top level directory after stripping.
+            The intention here is to allow using apko versions that are not included in versions.bzl
     """
     map = platform_to_apko_binary_map
     if map == None:

--- a/apko/repositories.bzl
+++ b/apko/repositories.bzl
@@ -121,7 +121,7 @@ def apko_register_toolchains(name, apko_version = LATEST_APKO_VERSION, platform_
             apko_binary_spec macro that consists of url to the archive with apko binary, it's sha256, version
             of apko and prefix that should be stripped after unpacking the archive. The prefix
             should specified, so that apko binary lands in top level directory after stripping.
-            The intention here is to allow using apko versions that are not included in versions.bzl
+            The intention here is to allow using apko versions that are not included in versions.bzl.
     """
     map = platform_to_apko_binary_map
     if map == None:

--- a/apko/repositories.bzl
+++ b/apko/repositories.bzl
@@ -127,6 +127,8 @@ def apko_register_toolchains(name, apko_version = LATEST_APKO_VERSION, platform_
     if map == None:
         map = _build_platform_to_apko_binary_map(apko_version)
     for platform, apko_spec in map.items():
+        if platform not in PLATFORMS.keys():
+            fail("Unsupported platform: {}".format(platform))
         apko_repositories(
             name = name + "_" + platform,
             platform = platform,

--- a/e2e/smoke/apko.lock.json
+++ b/e2e/smoke/apko.lock.json
@@ -35,22 +35,22 @@
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r6.apk",
-        "version": "1.36.1-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-d4qZgWeuvCwk1xxY8sqtpRDHT4E="
+          "range": "bytes=0-666",
+          "checksum": "sha1-a//l3+A49R6SnnktH1+pQuZE2qI="
         },
         "control": {
-          "range": "bytes=663-2297",
-          "checksum": "sha1-KNW4neQTQeKuinldJ+uwTCbJUYw="
+          "range": "bytes=667-2300",
+          "checksum": "sha1-ierGKl33AY17yZdo8YN+z8NeMPg="
         },
         "data": {
-          "range": "bytes=2298-946176",
-          "checksum": "sha256-EidJnLmLObMUZKKi4DrYHofZ+y5ltrdMR8hChYiRWrs="
+          "range": "bytes=2301-946176",
+          "checksum": "sha256-FzlpW4Mq56716OmdQnwYlES9hohBM0ouq62EWds3kDI="
         },
-        "checksum": "Q1KNW4neQTQeKuinldJ+uwTCbJUYw="
+        "checksum": "Q1ierGKl33AY17yZdo8YN+z8NeMPg="
       }
     ]
   }

--- a/e2e/smoke/multifile_config/apko.generated.lock.json
+++ b/e2e/smoke/multifile_config/apko.generated.lock.json
@@ -1,5 +1,9 @@
 {
   "version": "v1",
+  "config": {
+    "name": "multifile_config/final_config",
+    "checksum": "sha256-MSnniHz70jvjVUCXoODhAlzNWxY5Vdjb8UOK8gFF0bk="
+  },
   "contents": {
     "keyring": [],
     "repositories": [
@@ -31,22 +35,22 @@
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r5.apk",
-        "version": "1.36.1-r5",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-665",
-          "checksum": "sha1-oXF25kDE6Jja1iQ2psyt9nV+ddE="
+          "range": "bytes=0-666",
+          "checksum": "sha1-a//l3+A49R6SnnktH1+pQuZE2qI="
         },
         "control": {
-          "range": "bytes=666-2301",
-          "checksum": "sha1-aBWv1Kn2ASOLShUeDPoSLaozuMs="
+          "range": "bytes=667-2300",
+          "checksum": "sha1-ierGKl33AY17yZdo8YN+z8NeMPg="
         },
         "data": {
-          "range": "bytes=2302-946176",
-          "checksum": "sha256-pDdzepugl8LYISmpJ2wGr885gfpwo2hi9ZMf4dQTi5s="
+          "range": "bytes=2301-946176",
+          "checksum": "sha256-FzlpW4Mq56716OmdQnwYlES9hohBM0ouq62EWds3kDI="
         },
-        "checksum": "Q1aBWv1Kn2ASOLShUeDPoSLaozuMs="
+        "checksum": "Q1ierGKl33AY17yZdo8YN+z8NeMPg="
       }
     ]
   }

--- a/examples/lock/apko.lock.json
+++ b/examples/lock/apko.lock.json
@@ -35,22 +35,22 @@
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r6.apk",
-        "version": "1.36.1-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-d4qZgWeuvCwk1xxY8sqtpRDHT4E="
+          "range": "bytes=0-666",
+          "checksum": "sha1-a//l3+A49R6SnnktH1+pQuZE2qI="
         },
         "control": {
-          "range": "bytes=663-2297",
-          "checksum": "sha1-KNW4neQTQeKuinldJ+uwTCbJUYw="
+          "range": "bytes=667-2300",
+          "checksum": "sha1-ierGKl33AY17yZdo8YN+z8NeMPg="
         },
         "data": {
-          "range": "bytes=2298-946176",
-          "checksum": "sha256-EidJnLmLObMUZKKi4DrYHofZ+y5ltrdMR8hChYiRWrs="
+          "range": "bytes=2301-946176",
+          "checksum": "sha256-FzlpW4Mq56716OmdQnwYlES9hohBM0ouq62EWds3kDI="
         },
-        "checksum": "Q1KNW4neQTQeKuinldJ+uwTCbJUYw="
+        "checksum": "Q1ierGKl33AY17yZdo8YN+z8NeMPg="
       }
     ]
   }

--- a/examples/multi_arch_and_repo/apko.lock.json
+++ b/examples/multi_arch_and_repo/apko.lock.json
@@ -69,41 +69,41 @@
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/busybox-1.36.1-r6.apk",
-        "version": "1.36.1-r6",
-        "architecture": "aarch64",
-        "signature": {
-          "range": "bytes=0-668",
-          "checksum": "sha1-mQ7YliI6N+WRkYBeqN9TzPoqeKM="
-        },
-        "control": {
-          "range": "bytes=669-2277",
-          "checksum": "sha1-bb9PDfZCtSSpisnKQowqjIBARuw="
-        },
-        "data": {
-          "range": "bytes=2278-1048576",
-          "checksum": "sha256-luUM4QOPzi0fN4w5AavBM5izOUP2b2ONKZUvetK7/5M="
-        },
-        "checksum": "Q1bb9PDfZCtSSpisnKQowqjIBARuw="
-      },
-      {
-        "name": "busybox-binsh",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/busybox-binsh-1.36.1-r6.apk",
-        "version": "1.36.1-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/busybox-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-664",
-          "checksum": "sha1-4tK7N5pOOddPafFkfvD+RDwNTdc="
+          "checksum": "sha1-KTpg+mwd1C/7kix+qULw7kgzkoI="
         },
         "control": {
-          "range": "bytes=665-1225",
-          "checksum": "sha1-AU9jNJREvFTm3V7Ezt196mifBt4="
+          "range": "bytes=665-2271",
+          "checksum": "sha1-vBBmLumXtdQe44XcXSynu8Weo54="
         },
         "data": {
-          "range": "bytes=1226-8192",
-          "checksum": "sha256-HLjiXiEwwRhKcRA0Hcepeco5Z5TZzHx+eyxFRoRW4Jw="
+          "range": "bytes=2272-1048576",
+          "checksum": "sha256-XfxjplEKGsi5z9OKljYnEh6f2Z9n1xg3UjNx/sU4XSY="
         },
-        "checksum": "Q1AU9jNJREvFTm3V7Ezt196mifBt4="
+        "checksum": "Q1vBBmLumXtdQe44XcXSynu8Weo54="
+      },
+      {
+        "name": "busybox-binsh",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/busybox-binsh-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "bytes=0-663",
+          "checksum": "sha1-LyDHiNq2cOX7ub+rDsOigd4UGEI="
+        },
+        "control": {
+          "range": "bytes=664-1228",
+          "checksum": "sha1-oGhR2UtRJaGKA4O5tgahRv6QZbQ="
+        },
+        "data": {
+          "range": "bytes=1229-8192",
+          "checksum": "sha256-GJp0ONI9Gftg3Wl3ai/VQK4RRCOuiC2GlGfxcghD4Xk="
+        },
+        "checksum": "Q1oGhR2UtRJaGKA4O5tgahRv6QZbQ="
       },
       {
         "name": "ca-certificates",
@@ -373,22 +373,22 @@
       },
       {
         "name": "ssl_client",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/ssl_client-1.36.1-r6.apk",
-        "version": "1.36.1-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/ssl_client-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
         "architecture": "aarch64",
         "signature": {
           "range": "bytes=0-663",
-          "checksum": "sha1-aoqgVQrCNGi9CpdAHjGC4ZHd5wM="
+          "checksum": "sha1-fVkw6ngewRk/fU2W4bBk3P5EscU="
         },
         "control": {
-          "range": "bytes=664-1267",
-          "checksum": "sha1-3xCxy0sA7PR617bkwoM8X7wJfaU="
+          "range": "bytes=664-1265",
+          "checksum": "sha1-jhgMQoeZ7N/G+4fhycYb1OrePg0="
         },
         "data": {
-          "range": "bytes=1268-81920",
-          "checksum": "sha256-zI+IFxNSCQb15e0Ogr164EPQdSyvsn3veyuR+puDvqY="
+          "range": "bytes=1266-81920",
+          "checksum": "sha256-XpX29W4W3IKF7DBe7+jP8MGA7O5oc436D7hv8Kq+UPk="
         },
-        "checksum": "Q13xCxy0sA7PR617bkwoM8X7wJfaU="
+        "checksum": "Q1jhgMQoeZ7N/G+4fhycYb1OrePg0="
       },
       {
         "name": "curl",
@@ -848,41 +848,41 @@
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r6.apk",
-        "version": "1.36.1-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-d4qZgWeuvCwk1xxY8sqtpRDHT4E="
+          "range": "bytes=0-666",
+          "checksum": "sha1-a//l3+A49R6SnnktH1+pQuZE2qI="
         },
         "control": {
-          "range": "bytes=663-2297",
-          "checksum": "sha1-KNW4neQTQeKuinldJ+uwTCbJUYw="
+          "range": "bytes=667-2300",
+          "checksum": "sha1-ierGKl33AY17yZdo8YN+z8NeMPg="
         },
         "data": {
-          "range": "bytes=2298-946176",
-          "checksum": "sha256-EidJnLmLObMUZKKi4DrYHofZ+y5ltrdMR8hChYiRWrs="
+          "range": "bytes=2301-946176",
+          "checksum": "sha256-FzlpW4Mq56716OmdQnwYlES9hohBM0ouq62EWds3kDI="
         },
-        "checksum": "Q1KNW4neQTQeKuinldJ+uwTCbJUYw="
+        "checksum": "Q1ierGKl33AY17yZdo8YN+z8NeMPg="
       },
       {
         "name": "busybox-binsh",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-binsh-1.36.1-r6.apk",
-        "version": "1.36.1-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/busybox-binsh-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-665",
-          "checksum": "sha1-93+JmDB+xwV/WFkC+mNBPhfuBoc="
+          "checksum": "sha1-u1tzjEMpXtpc7Al5/UkwM3r9Avs="
         },
         "control": {
-          "range": "bytes=666-1251",
-          "checksum": "sha1-wa39cNs6hgUKJi1R9VK3OzppxMg="
+          "range": "bytes=666-1255",
+          "checksum": "sha1-bChMYpNVeA+TjgHg35IplQm8/Y4="
         },
         "data": {
-          "range": "bytes=1252-8192",
-          "checksum": "sha256-HLjiXiEwwRhKcRA0Hcepeco5Z5TZzHx+eyxFRoRW4Jw="
+          "range": "bytes=1256-8192",
+          "checksum": "sha256-GJp0ONI9Gftg3Wl3ai/VQK4RRCOuiC2GlGfxcghD4Xk="
         },
-        "checksum": "Q1wa39cNs6hgUKJi1R9VK3OzppxMg="
+        "checksum": "Q1bChMYpNVeA+TjgHg35IplQm8/Y4="
       },
       {
         "name": "ca-certificates",
@@ -1152,22 +1152,22 @@
       },
       {
         "name": "ssl_client",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/ssl_client-1.36.1-r6.apk",
-        "version": "1.36.1-r6",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/ssl_client-1.36.1-r7.apk",
+        "version": "1.36.1-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-662",
-          "checksum": "sha1-zJ0i0iZSBJjYDPrlYjQvN/o/rz4="
+          "range": "bytes=0-665",
+          "checksum": "sha1-A1xWqbTYfuF+X9fPuXhj7/Rcec4="
         },
         "control": {
-          "range": "bytes=663-1291",
-          "checksum": "sha1-khfMSMr4I/TB71tr+of1zjfXexg="
+          "range": "bytes=666-1292",
+          "checksum": "sha1-x4zGPlbjZ/7ZsYMAtZPaGWTob/k="
         },
         "data": {
-          "range": "bytes=1292-28672",
-          "checksum": "sha256-RRzqtpea+c0fBkT64n51NryMzdrroyY/4KnqCbwdTgw="
+          "range": "bytes=1293-28672",
+          "checksum": "sha256-H07jw+rEEytm2I6bZRCDLOpUCBMS9YWgo3wytw3V6V8="
         },
-        "checksum": "Q1khfMSMr4I/TB71tr+of1zjfXexg="
+        "checksum": "Q1x4zGPlbjZ/7ZsYMAtZPaGWTob/k="
       },
       {
         "name": "curl",

--- a/examples/oci/apko.lock.json
+++ b/examples/oci/apko.lock.json
@@ -159,41 +159,41 @@
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-695",
-          "checksum": "sha1-NOr3QkdAoYtVFUHqDHFlZDE7XOA="
+          "range": "bytes=0-699",
+          "checksum": "sha1-MhtOLO8bsTSA4C3Kx3E6fAYocpo="
         },
         "control": {
-          "range": "bytes=696-1086",
-          "checksum": "sha1-zJF4jMqvBOZMsIeFxVFdtQ3rSfU="
+          "range": "bytes=700-1091",
+          "checksum": "sha1-uosIfp6C/h6P+sXGk/la4JDXXeE="
         },
         "data": {
-          "range": "bytes=1087-4977874",
-          "checksum": "sha256-TdZ+P8LhZEtCFwqHB8EopygK7kVisWAdqVQp2SR81Mw="
+          "range": "bytes=1092-4977993",
+          "checksum": "sha256-E83CgKEbWWR4lq2FXRBh+euAGW3o/vuv94bb2Q+K0zA="
         },
-        "checksum": "Q1zJF4jMqvBOZMsIeFxVFdtQ3rSfU="
+        "checksum": "Q1uosIfp6C/h6P+sXGk/la4JDXXeE="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-698",
-          "checksum": "sha1-qbSu4ADMLCa8av1MHENYm0KpeVU="
+          "range": "bytes=0-700",
+          "checksum": "sha1-/I+Sd7tui6dhzdIMBzl6Tv+7QyA="
         },
         "control": {
-          "range": "bytes=699-1093",
-          "checksum": "sha1-AsWw6x+FKAaD0QLSm7+OgYnsUfw="
+          "range": "bytes=701-1094",
+          "checksum": "sha1-p4QZS6fe4UidzvE37yGYecrXTMc="
         },
         "data": {
-          "range": "bytes=1094-1206211",
-          "checksum": "sha256-qcxjM26OWPb2xrggwh1U3RvYlk3f7R8R5KFEZ6DmI0s="
+          "range": "bytes=1095-1206210",
+          "checksum": "sha256-j/FBEZzD7MPj2wT9unq2cKhLJV/8qm6DJCPog3heIvM="
         },
-        "checksum": "Q1AsWw6x+FKAaD0QLSm7+OgYnsUfw="
+        "checksum": "Q1p4QZS6fe4UidzvE37yGYecrXTMc="
       },
       {
         "name": "apk-tools",
@@ -425,41 +425,41 @@
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-698",
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0="
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA="
         },
         "control": {
-          "range": "bytes=699-1079",
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME="
+          "range": "bytes=699-1076",
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU="
         },
         "data": {
-          "range": "bytes=1080-5915633",
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM="
+          "range": "bytes=1077-5915704",
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4="
         },
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME="
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-696",
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY="
+          "range": "bytes=0-694",
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k="
         },
         "control": {
-          "range": "bytes=697-1082",
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw="
+          "range": "bytes=695-1079",
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI="
         },
         "data": {
-          "range": "bytes=1083-1197082",
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM="
+          "range": "bytes=1080-1197081",
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y="
         },
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw="
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI="
       },
       {
         "name": "apk-tools",

--- a/examples/wolfi-base/apko.lock.json
+++ b/examples/wolfi-base/apko.lock.json
@@ -159,41 +159,41 @@
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9",
         "architecture": "x86_64",
         "signature": {
           "range": "bytes=0-698",
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0="
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA="
         },
         "control": {
-          "range": "bytes=699-1079",
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME="
+          "range": "bytes=699-1076",
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU="
         },
         "data": {
-          "range": "bytes=1080-5915633",
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM="
+          "range": "bytes=1077-5915704",
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4="
         },
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME="
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-696",
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY="
+          "range": "bytes=0-694",
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k="
         },
         "control": {
-          "range": "bytes=697-1082",
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw="
+          "range": "bytes=695-1079",
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI="
         },
         "data": {
-          "range": "bytes=1083-1197082",
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM="
+          "range": "bytes=1080-1197081",
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y="
         },
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw="
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI="
       },
       {
         "name": "apk-tools",
@@ -425,41 +425,41 @@
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-695",
-          "checksum": "sha1-NOr3QkdAoYtVFUHqDHFlZDE7XOA="
+          "range": "bytes=0-699",
+          "checksum": "sha1-MhtOLO8bsTSA4C3Kx3E6fAYocpo="
         },
         "control": {
-          "range": "bytes=696-1086",
-          "checksum": "sha1-zJF4jMqvBOZMsIeFxVFdtQ3rSfU="
+          "range": "bytes=700-1091",
+          "checksum": "sha1-uosIfp6C/h6P+sXGk/la4JDXXeE="
         },
         "data": {
-          "range": "bytes=1087-4977874",
-          "checksum": "sha256-TdZ+P8LhZEtCFwqHB8EopygK7kVisWAdqVQp2SR81Mw="
+          "range": "bytes=1092-4977993",
+          "checksum": "sha256-E83CgKEbWWR4lq2FXRBh+euAGW3o/vuv94bb2Q+K0zA="
         },
-        "checksum": "Q1zJF4jMqvBOZMsIeFxVFdtQ3rSfU="
+        "checksum": "Q1uosIfp6C/h6P+sXGk/la4JDXXeE="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-698",
-          "checksum": "sha1-qbSu4ADMLCa8av1MHENYm0KpeVU="
+          "range": "bytes=0-700",
+          "checksum": "sha1-/I+Sd7tui6dhzdIMBzl6Tv+7QyA="
         },
         "control": {
-          "range": "bytes=699-1093",
-          "checksum": "sha1-AsWw6x+FKAaD0QLSm7+OgYnsUfw="
+          "range": "bytes=701-1094",
+          "checksum": "sha1-p4QZS6fe4UidzvE37yGYecrXTMc="
         },
         "data": {
-          "range": "bytes=1094-1206211",
-          "checksum": "sha256-qcxjM26OWPb2xrggwh1U3RvYlk3f7R8R5KFEZ6DmI0s="
+          "range": "bytes=1095-1206210",
+          "checksum": "sha256-j/FBEZzD7MPj2wT9unq2cKhLJV/8qm6DJCPog3heIvM="
         },
-        "checksum": "Q1AsWw6x+FKAaD0QLSm7+OgYnsUfw="
+        "checksum": "Q1p4QZS6fe4UidzvE37yGYecrXTMc="
       },
       {
         "name": "apk-tools",

--- a/scripts/update_locks.sh
+++ b/scripts/update_locks.sh
@@ -15,8 +15,7 @@ repo_root=$(pwd)
 for workspace in "." "./e2e/smoke"; do
   cd $workspace
   for target in $(bazel query "kind(apko_lock, //...)"); do 
-    echo $target
-    #bazel run $target
+    bazel run $target
   done
   cd $repo_root
 done


### PR DESCRIPTION
The motivation here is to be able to use newest apko releases without updating rules_apko as an intermediate step.

It offloads some complexity (specifying hash, prefix to strip and url to the user), but if one just wants to use default apko version, they don't need to do it.