### PR TITLE
Stop testing on Bazel 6

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
-    bazel: ["6.x", "7.x"]
+    bazel: ["7.x"]
     platform: ["debian10", "macos", "ubuntu2004"]
   tasks:
     run_tests:


### PR DESCRIPTION
There were errors on Bazel Central Registry because the credential helpers workaround requires setup. Bazel 7 has correct support for Range headers, and is the LTS version.