### PR TITLE
Allow specyfying 'args' for apko_lock.

### DIFF
--- a/apko/private/apko_lock.bzl
+++ b/apko/private/apko_lock.bzl
@@ -20,7 +20,7 @@ set -e
 config={{config}}
 output={{output}}
 
-{{apko_binary}} lock $config --output=${BUILD_WORKSPACE_DIRECTORY}/${output} ${args} "${@}"
+{{apko_binary}} lock $config --output=${BUILD_WORKSPACE_DIRECTORY}/${output} "${@}"
 """
 
 def _impl(ctx):

--- a/apko/private/apko_lock.bzl
+++ b/apko/private/apko_lock.bzl
@@ -20,7 +20,7 @@ set -e
 config={{config}}
 output={{output}}
 
-{{apko_binary}} lock $config --output=${BUILD_WORKSPACE_DIRECTORY}/${output}
+{{apko_binary}} lock $config --output=${BUILD_WORKSPACE_DIRECTORY}/${output} ${args} "${@}"
 """
 
 def _impl(ctx):
@@ -55,7 +55,7 @@ _apko_lock = rule(
     toolchains = ["@rules_apko//apko:toolchain_type"],
 )
 
-def apko_lock(name, config, lockfile_name):
+def apko_lock(name, config, lockfile_name, **kwargs):
     """Generates executable rule for producing apko lock files.
 
     When run, the rule will output the lockfile to the lockfile_name in the directory of the package where the rule is defined.
@@ -67,10 +67,12 @@ def apko_lock(name, config, lockfile_name):
         config: label of the apko config. It can be either a source file or generated target. Additionally, if the target provides ApkoConfigInfo provider,
             the transitive dependencies listed in ApkoConfigInfo.files will be added to runfiles as well.
         lockfile_name: name of the lockfile
+        **kwargs: the rule inherits standard attributes, like: tags, visibility, and args.
     """
     config_label = native.package_relative_label(config)
     _apko_lock(
         name = name,
         config = config,
         lockfile_name = paths.join(config_label.package, lockfile_name),
+        **kwargs
     )

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -160,7 +160,7 @@ For more examples checkout the [examples](/examples) directory.
 <pre>
 load("@rules_apko//apko:defs.bzl", "apko_lock")
 
-apko_lock(<a href="#apko_lock-name">name</a>, <a href="#apko_lock-config">config</a>, <a href="#apko_lock-lockfile_name">lockfile_name</a>)
+apko_lock(<a href="#apko_lock-name">name</a>, <a href="#apko_lock-config">config</a>, <a href="#apko_lock-lockfile_name">lockfile_name</a>,  <a href="#apko_lock-kwargs">kwargs</a>)
 </pre>
 
 Generates executable rule for producing apko lock files.
@@ -178,5 +178,4 @@ That is, if you define `apko_lock` in `foo/bar/BUILD.bazel` with `lockfile_name=
 | <a id="apko_lock-name"></a>name |  name of the rule,   |  none |
 | <a id="apko_lock-config"></a>config |  label of the apko config. It can be either a source file or generated target. Additionally, if the target provides ApkoConfigInfo provider, the transitive dependencies listed in ApkoConfigInfo.files will be added to runfiles as well.   |  none |
 | <a id="apko_lock-lockfile_name"></a>lockfile_name |  name of the lockfile   |  none |
-
-
+| <a id="apko_lock-kwargs"></a>kwargs |  the rule inherits standard attributes, like: tags, visibility, and args.   |  none |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -179,4 +179,5 @@ That is, if you define `apko_lock` in `foo/bar/BUILD.bazel` with `lockfile_name=
 | <a id="apko_lock-config"></a>config |  label of the apko config. It can be either a source file or generated target. Additionally, if the target provides ApkoConfigInfo provider, the transitive dependencies listed in ApkoConfigInfo.files will be added to runfiles as well.   |  none |
 | <a id="apko_lock-lockfile_name"></a>lockfile_name |  name of the lockfile   |  none |
 | <a id="apko_lock-kwargs"></a>kwargs |  the rule inherits standard attributes, like: tags, visibility, and args.   |  none |
-q
+
+

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -160,7 +160,7 @@ For more examples checkout the [examples](/examples) directory.
 <pre>
 load("@rules_apko//apko:defs.bzl", "apko_lock")
 
-apko_lock(<a href="#apko_lock-name">name</a>, <a href="#apko_lock-config">config</a>, <a href="#apko_lock-lockfile_name">lockfile_name</a>,  <a href="#apko_lock-kwargs">kwargs</a>)
+apko_lock(<a href="#apko_lock-name">name</a>, <a href="#apko_lock-config">config</a>, <a href="#apko_lock-lockfile_name">lockfile_name</a>, <a href="#apko_lock-kwargs">kwargs</a>)
 </pre>
 
 Generates executable rule for producing apko lock files.
@@ -179,3 +179,4 @@ That is, if you define `apko_lock` in `foo/bar/BUILD.bazel` with `lockfile_name=
 | <a id="apko_lock-config"></a>config |  label of the apko config. It can be either a source file or generated target. Additionally, if the target provides ApkoConfigInfo provider, the transitive dependencies listed in ApkoConfigInfo.files will be added to runfiles as well.   |  none |
 | <a id="apko_lock-lockfile_name"></a>lockfile_name |  name of the lockfile   |  none |
 | <a id="apko_lock-kwargs"></a>kwargs |  the rule inherits standard attributes, like: tags, visibility, and args.   |  none |
+q

--- a/docs/translate_lock.md
+++ b/docs/translate_lock.md
@@ -25,3 +25,5 @@ See [apko-cache.md](./apko-cache.md) documentation.
 | <a id="translate_apko_lock-lock"></a>lock |  label to the `apko.lock.json` file.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="translate_apko_lock-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 | <a id="translate_apko_lock-target_name"></a>target_name |  internal. do not use!   | String | optional |  `""`  |
+
+

--- a/docs/translate_lock.md
+++ b/docs/translate_lock.md
@@ -25,5 +25,3 @@ See [apko-cache.md](./apko-cache.md) documentation.
 | <a id="translate_apko_lock-lock"></a>lock |  label to the `apko.lock.json` file.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="translate_apko_lock-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 | <a id="translate_apko_lock-target_name"></a>target_name |  internal. do not use!   | String | optional |  `""`  |
-
-

--- a/e2e/smoke/multifile_config/BUILD
+++ b/e2e/smoke/multifile_config/BUILD
@@ -30,8 +30,12 @@ build_test(
 
 apko_lock(
     name = "lock_from_generated_config",
+    args = [
+        "--log-level=debug",  # illustration that you can pass args to the executables (bazel run) rules
+    ],
     config = ":final_config",
     lockfile_name = "apko.generated.lock.json",
+    visibility = ["//visibility:private"],  # illustration that you can control visibility.
 )
 
 apko_show_config(


### PR DESCRIPTION
The original reason was to enables passing: '--ignore-signatures' due to problems with artifactory support for rsa keys.
But this also brings consistency with apko_build.
