### PR TITLE
Update bazel modules to newer versions.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,25 +7,18 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "aspect_bazel_lib", version = "1.40.3")
-
-# We need this fix https://github.com/aspect-build/bazel-lib/pull/713 to be able to generate docs
-single_version_override(
-    module_name = "aspect_bazel_lib",
-    version = "2.5.3",
-)
-
-bazel_dep(name = "container_structure_test", version = "1.15.0", dev_dependency = True)
-bazel_dep(name = "rules_pkg", version = "1.0.1", dev_dependency = True)
-bazel_dep(name = "rules_oci", version = "1.3.3", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.34.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "aspect_bazel_lib", version = "2.16.0")
+bazel_dep(name = "container_structure_test", version = "1.16.0", dev_dependency = True)
+bazel_dep(name = "rules_pkg", version = "1.1.0", dev_dependency = True)
+bazel_dep(name = "rules_oci", version = "1.8.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.43.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.7.1", dev_dependency = True)
-bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
-bazel_dep(name = "stardoc", version = "0.7.1", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True, repo_name = "io_bazel_stardoc")
 
 toolchain = use_extension("//apko:extensions.bzl", "apko")
-toolchain.toolchain(apko_version = "v0.27.0")
+toolchain.toolchain(apko_version = "v0.27.1")
 use_repo(toolchain, "apko_toolchains")
 
 register_toolchains("@apko_toolchains//:all")

--- a/apko/BUILD.bazel
+++ b/apko/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//apko/private:resolved_toolchain.bzl", "resolved_toolchain")
 load("@rules_apko//apko/private:apko_run.bzl", "apko_run")
+load("//apko/private:resolved_toolchain.bzl", "resolved_toolchain")
 
 # For stardoc to reference the files
 exports_files([

--- a/apko/private/BUILD.bazel
+++ b/apko/private/BUILD.bazel
@@ -39,19 +39,17 @@ bzl_library(
 )
 
 bzl_library(
-    name = "apko_config",
-    srcs = [
-        "apko_config.bzl",
-        "@bazel_skylib//lib:paths",
-    ],
-    visibility = ["//apko:__subpackages__"],
-)
-
-bzl_library(
     name = "apko_show_config",
     srcs = ["apko_show_config.bzl"],
     visibility = ["//apko:__subpackages__"],
     deps = [":apko_config"],
+)
+
+bzl_library(
+    name = "apko_config",
+    srcs = ["apko_config.bzl"],
+    visibility = ["//apko:__subpackages__"],
+    deps = ["@bazel_skylib//lib:paths"],
 )
 
 bzl_library(

--- a/apko/private/versions.bzl
+++ b/apko/private/versions.bzl
@@ -3,6 +3,13 @@
 # Add new versions by running
 # ./scripts/mirror_apko.sh
 APKO_VERSIONS = {
+    "v0.27.1": {
+        "darwin_amd64": "sha256-OC6+2I5FIDuG5Uq3EaiNGjlnqLvEbbQmwOCc1HUgaTM=",
+        "darwin_arm64": "sha256-aWEL7e6IH668V41TXySE3ee2Tf4J8USNb6TVtWhDZm8=",
+        "linux_386": "sha256-S5FNhlypB3MW7ImWD0CqMdTrI/hB/BdUw/eAl0C5jPA=",
+        "linux_amd64": "sha256-nXKpTcnR1tyrw04b6Hxc56JtCsv5Di1OHs8eMt4uCI0=",
+        "linux_arm64": "sha256-Vg/nxGglpqLdXhtMswOKcnzp2kT+nY4AM7KwsxnLfQ4=",
+    },
     "v0.27.0": {
         "darwin_amd64": "sha256-j3iOAAJWGU1hPZs0ApfdFAW5QEU2O8RMsSkPokD6G4c=",
         "darwin_arm64": "sha256-/7NO3G9Nx/NjDeFGGbnEdBgY0iZ82pfJoPiFEcUh1U4=",

--- a/apko/tests/versions_test.bzl
+++ b/apko/tests/versions_test.bzl
@@ -7,7 +7,7 @@ load("//apko/private:versions.bzl", "APKO_VERSIONS")
 
 def _smoke_test_impl(ctx):
     env = unittest.begin(ctx)
-    asserts.equals(env, "v0.27.0", APKO_VERSIONS.keys()[0])
+    asserts.equals(env, "v0.27.1", APKO_VERSIONS.keys()[0])
     return unittest.end(env)
 
 # The unittest library requires that we export the test cases as named test rules,

--- a/examples/lock/BUILD.bazel
+++ b/examples/lock/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_apko//apko:defs.bzl", "apko_image")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_apko//apko:defs.bzl", "apko_image")
 
 # An example demonstrating how to use alpine packages with a lock file.
 # See MODULE.bazel for how apko.lock.json is translated to @examples_lock//:contents

--- a/examples/multi_arch_and_repo/BUILD.bazel
+++ b/examples/multi_arch_and_repo/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_apko//apko:defs.bzl", "apko_image")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_apko//apko:defs.bzl", "apko_image")
 
 # An example demonstrating how to use multi architecture alpine packages with a lock file.
 # See MODULE.bazel for how apko.lock.json is translated to @examples_multi_arch_and_repo//:contents

--- a/examples/oci/BUILD.bazel
+++ b/examples/oci/BUILD.bazel
@@ -1,7 +1,7 @@
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_apko//apko:defs.bzl", "apko_image")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 # An example demonstrating how to use apko_image with rules_oci
 # See MODULE.bazel for how apko.lock.json is translated to @examples_oci//:contents

--- a/examples/wolfi-base/BUILD.bazel
+++ b/examples/wolfi-base/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_apko//apko:defs.bzl", "apko_image")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_apko//apko:defs.bzl", "apko_image")
 
 # An example demonstrating how to use wolfi packages with a lock file.
 # See MODULE.bazel for how apko.lock.json is translated to @examples_wolfi_base//:contents


### PR DESCRIPTION
In particular, `rules_oci` will show more useful failures.