### PR TITLE
Drop tests on windows and macosx, unsupported

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,16 +34,8 @@ jobs:
           egress-policy: audit
       - id: linux
         run: echo "os=ubuntu-latest" >> $GITHUB_OUTPUT
-      - id: windows
-        run: echo "os=windows-latest" >> $GITHUB_OUTPUT
-        # Only run on main branch (or PR branches that contain 'windows') to minimize Windows minutes (billed at 2X)
-        if: (github.ref == 'refs/heads/main' || contains(github.head_ref, 'windows')) && !inputs.exclude_windows
-      - id: macos
-        run: echo "os=macos-latest" >> $GITHUB_OUTPUT
-        # Only run on main branch (or PR branches that contain 'macos') to minimize macOS minutes (billed at 10X)
-        if: github.ref == 'refs/heads/main' || contains(github.head_ref, 'macos')
     outputs:
-      # Will look like ["ubuntu-latest", "windows-latest", "macos-latest"]
+      # Will look like ["ubuntu-latest"]
       os: ${{ toJSON(steps.*.outputs.os) }}
 
   matrix-prep-bazelversion:


### PR DESCRIPTION
Drop tests on windows & macosx, as some of the CI steps expect native
linux execution capabilities, and are now failing.
