### PR TITLE
Upgrade to latest bazel 6 and 7

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-7.1.0
+7.6.1
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - id: bazel_from_bazelversion
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_6
-        run: echo "bazelversion=6.3.0" >> $GITHUB_OUTPUT
+        run: echo "bazelversion=6.5.0" >> $GITHUB_OUTPUT
     outputs:
       # Will look like ["<version from .bazelversion>", "x.y.z"]
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
@@ -79,7 +79,7 @@ jobs:
           - bzlmodEnabled: false
             folder: .
           # Root module uses newer stardoc that requires Bazel 7 or greater
-          - bazelversion: 6.3.0
+          - bazelversion: 6.5.0
             folder: .
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -110,7 +110,7 @@ jobs:
 
       # Required for rules_apko to make range requests
       - name: Add bazel 6 workaround
-        if: ${{ matrix.bazelversion == '6.3.0' }}
+        if: ${{ matrix.bazelversion == '6.5.0' }}
         run: echo 'try-import %workspace%/.apko/.bazelrc' >> .bazelrc
 
       - name: Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - id: bazel_82
+        run: echo "bazelversion=8.2.1" >> $GITHUB_OUTPUT
       # NB: we assume this is Bazel 7
       - id: bazel_from_bazelversion
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,8 @@ jobs:
       # NB: we assume this is Bazel 7
       - id: bazel_from_bazelversion
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
+      - id: bazel_71
+        run: echo "bazelversion=7.1.0" >> $GITHUB_OUTPUT
       - id: bazel_6
         run: echo "bazelversion=6.5.0" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
Upgrade CI to latest releases of bazel 6 and 7.

Note 7.6.1 support was tested separately in:
- https://github.com/chainguard-dev/rules_apko/pull/125

Somebody with powers needs to lift 7.1.0 as a required check.