### PR TITLE
release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ on:
       - "v*.*.*"
 
 permissions:
+  id-token: write
   contents: write
+  attestations: write
 
 jobs:
   release:


### PR DESCRIPTION
Release workflow wants more permissions:

```
Invalid workflow file: .github/workflows/release.yml#L15
The workflow is not valid. .github/workflows/release.yml (Line: 15, Col: 3): Error calling workflow 'bazel-contrib/.github/.github/workflows/release_ruleset.yaml@9ed8d86404ac3214f80cfb02e49f44a1b28b17b0'. The nested job 'attest' is requesting 'attestations: write, id-token: write', but is only allowed 'attestations: none, id-token: none'.
```

Seems like it wants to attest itself.
