### PR TITLE
Remove leading newline from launcher template

### DIFF
--- a/apko/private/apko_lock.bzl
+++ b/apko/private/apko_lock.bzl
@@ -12,8 +12,7 @@ _DOC = """
 apko_lock generates the lock file based on the provided config.
 """
 
-LAUNCHER_TEMPLATE = """
-#!/usr/bin/env sh
+LAUNCHER_TEMPLATE = """#!/usr/bin/env sh
 
 set -e
 

--- a/apko/private/apko_run.bzl
+++ b/apko/private/apko_run.bzl
@@ -22,8 +22,7 @@ Thanks to this, `bazel run @rules_apko//apko {flags}` can be called, without nee
 The workdir of the running command is the directory from which bazel has been called.
 """
 
-LAUNCHER_TEMPLATE = """
-#!/usr/bin/env bash
+LAUNCHER_TEMPLATE = """#!/usr/bin/env bash
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
 set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash


### PR DESCRIPTION
Also remove leading newline from LAUNCHER_TEMPLATE other examples of
such wrappers do not have a leading newline.

Reference example is https://github.com/bazel-contrib/rules_jvm_external/blob/d8af22108bd8b353a226140570008231f2921931/private/rules/maven_publish.bzl#L12
