### PR TITLE
bcr: update presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,8 +1,8 @@
 bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
-    bazel: ["7.x"]
-    platform: ["debian10", "macos", "ubuntu2004"]
+    bazel: ["7.x", "8.x"]
+    platform: ["debian11", "ubuntu2204"]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Support for bazel 8 was added, and support for macos dropped. Plus
upgrade platfroms to newer debian and ubuntu releases.

Maybe this was blocking release to bcr.
