### PR TITLE
switch to user repo rule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,11 +76,7 @@ jobs:
         folder:
           - .
           - e2e/smoke
-        bzlmodEnabled: [true, false]
         exclude:
-          # Root module is BZLMOD only, do not test it without bzlmod enabled.
-          - bzlmodEnabled: false
-            folder: .
           # Root module uses newer stardoc that requires Bazel 7 or greater
           - bazelversion: 6.5.0
             folder: .
@@ -98,7 +94,7 @@ jobs:
         with:
           repository-cache: true
           bazelrc: |
-            common --announce_rc --color=yes --enable_bzlmod=${{ matrix.bzlmodEnabled }}
+            common --announce_rc --color=yes --enable_bzlmod
             test --test_output=errors
 
       - name: Configure Bazel version
@@ -107,7 +103,7 @@ jobs:
 
       # See https://github.com/bazel-contrib/publish-to-bcr#including-patches
       - name: verify bcr patches
-        if: matrix.bzlmodEnabled && hashFiles('.bcr/patches/*.patch') != ''
+        if: hashFiles('.bcr/patches/*.patch') != ''
         run: patch --dry-run -p1 < .bcr/patches/*.patch
 
       # Required for rules_apko to make range requests

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -1,4 +1,6 @@
 # Override http_archive for local testing
+load("@bazel//tools/build_defs/repo:local.bzl", "local_repository")
+
 local_repository(
     name = "rules_apko",
     path = "../..",


### PR DESCRIPTION
- **Migrate from native to starlark use_repo_rule for local_repository**
  Migrate in e2e test from native to starlark use_repo_rule for
  local_repository.
  
  References:
  - https://github.com/chainguard-dev/rules_apko/issues/147
  - https://github.com/bazelbuild/bazel-central-registry/pull/5033
  - https://github.com/bazelbuild/bazel/issues/22080
  

- **Require bzlmod**
  