### PR TITLE
tests: stop using workspaces for tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,11 +109,6 @@ jobs:
         if: ${{ matrix.bazelversion == '6.5.0' }}
         run: echo 'try-import %workspace%/.apko/.bazelrc' >> .bazelrc
 
-      # Tests currently assume workspace is true
-      - name: Add bazel 8 workaround
-        if: ${{ startsWith(matrix.bazelversion, '8.') }}
-        run: sed '/^common/s|$| --enable_workspace=true|' -i .bazelrc
-
       - name: Test
         working-directory: ${{ matrix.folder }}
         if: ${{ startsWith(matrix.bazelversion, '8.') || matrix.folder != '.' }}


### PR DESCRIPTION
I expected this to fail, but CI passes.

I guess we don't require or need work spaces after-all?

Fixes: #159