### PR TITLE
Update locks

### DIFF
--- a/e2e/smoke/apko.lock.json
+++ b/e2e/smoke/apko.lock.json
@@ -36,22 +36,22 @@
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/busybox-1.37.0-r12.apk",
-        "version": "1.37.0-r12",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/busybox-1.37.0-r13.apk",
+        "version": "1.37.0-r13",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-r/7JUCUj8w6vDCN8URQBSadT49I="
+          "range": "bytes=0-663",
+          "checksum": "sha1-MOQ6w2biPOYOcZPvv/aymkYlKAM="
         },
         "control": {
-          "range": "bytes=665-2379",
-          "checksum": "sha1-sSNCl4MTQ0d1V/0NTXAhIjY7Nqo="
+          "range": "bytes=664-2376",
+          "checksum": "sha1-hUDISHIUJoVnYf5xnUr4chLAgJ4="
         },
         "data": {
-          "range": "bytes=2380-505880",
-          "checksum": "sha256-AxToQ9W4f6KDe7yrWkpOU9vEJhWvdo0nGTWDsxqXGwY="
+          "range": "bytes=2377-505886",
+          "checksum": "sha256-Dyow/DltfwMNfKUwwxkQXKchOTJGKqJQX/oU/SWBWXM="
         },
-        "checksum": "Q1sSNCl4MTQ0d1V/0NTXAhIjY7Nqo="
+        "checksum": "Q1hUDISHIUJoVnYf5xnUr4chLAgJ4="
       }
     ]
   }

--- a/e2e/smoke/multifile_config/apko.generated.lock.json
+++ b/e2e/smoke/multifile_config/apko.generated.lock.json
@@ -36,22 +36,22 @@
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/busybox-1.37.0-r12.apk",
-        "version": "1.37.0-r12",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/busybox-1.37.0-r13.apk",
+        "version": "1.37.0-r13",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-r/7JUCUj8w6vDCN8URQBSadT49I="
+          "range": "bytes=0-663",
+          "checksum": "sha1-MOQ6w2biPOYOcZPvv/aymkYlKAM="
         },
         "control": {
-          "range": "bytes=665-2379",
-          "checksum": "sha1-sSNCl4MTQ0d1V/0NTXAhIjY7Nqo="
+          "range": "bytes=664-2376",
+          "checksum": "sha1-hUDISHIUJoVnYf5xnUr4chLAgJ4="
         },
         "data": {
-          "range": "bytes=2380-505880",
-          "checksum": "sha256-AxToQ9W4f6KDe7yrWkpOU9vEJhWvdo0nGTWDsxqXGwY="
+          "range": "bytes=2377-505886",
+          "checksum": "sha256-Dyow/DltfwMNfKUwwxkQXKchOTJGKqJQX/oU/SWBWXM="
         },
-        "checksum": "Q1sSNCl4MTQ0d1V/0NTXAhIjY7Nqo="
+        "checksum": "Q1hUDISHIUJoVnYf5xnUr4chLAgJ4="
       }
     ]
   }

--- a/examples/lock/apko.lock.json
+++ b/examples/lock/apko.lock.json
@@ -36,22 +36,22 @@
       },
       {
         "name": "busybox",
-        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/busybox-1.37.0-r12.apk",
-        "version": "1.37.0-r12",
+        "url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/busybox-1.37.0-r13.apk",
+        "version": "1.37.0-r13",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-664",
-          "checksum": "sha1-r/7JUCUj8w6vDCN8URQBSadT49I="
+          "range": "bytes=0-663",
+          "checksum": "sha1-MOQ6w2biPOYOcZPvv/aymkYlKAM="
         },
         "control": {
-          "range": "bytes=665-2379",
-          "checksum": "sha1-sSNCl4MTQ0d1V/0NTXAhIjY7Nqo="
+          "range": "bytes=664-2376",
+          "checksum": "sha1-hUDISHIUJoVnYf5xnUr4chLAgJ4="
         },
         "data": {
-          "range": "bytes=2380-505880",
-          "checksum": "sha256-AxToQ9W4f6KDe7yrWkpOU9vEJhWvdo0nGTWDsxqXGwY="
+          "range": "bytes=2377-505886",
+          "checksum": "sha256-Dyow/DltfwMNfKUwwxkQXKchOTJGKqJQX/oU/SWBWXM="
         },
-        "checksum": "Q1sSNCl4MTQ0d1V/0NTXAhIjY7Nqo="
+        "checksum": "Q1hUDISHIUJoVnYf5xnUr4chLAgJ4="
       }
     ]
   }

--- a/examples/multi_arch_and_repo/apko.lock.json
+++ b/examples/multi_arch_and_repo/apko.lock.json
@@ -41,649 +41,649 @@
     "packages": [
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r20.apk",
-        "version": "20230201-r20",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r23.apk",
+        "version": "20230201-r23",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1658",
-          "checksum": "sha1-TLw5hBAy1hwBFm43m8CKTMGqRsg="
+          "range": "bytes=0-1774",
+          "checksum": "sha1-Edys7TY5uMhTMVJFCJoJnyP+fto="
         },
         "data": {
-          "range": "bytes=1659-13087",
-          "checksum": "sha256-dkSH8iqPyo9sUEmojZXTg3a4DGVb31OcVC/8fWWjwQQ="
+          "range": "bytes=1775-13309",
+          "checksum": "sha256-tJMlBeVIuLFjzxKfPNGcf38QRHFcPpWGoYvQuPLXx3I="
         },
-        "checksum": "Q1TLw5hBAy1hwBFm43m8CKTMGqRsg="
+        "checksum": "Q1Edys7TY5uMhTMVJFCJoJnyP+fto="
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20241121-r40.apk",
-        "version": "20241121-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20250619-r5.apk",
+        "version": "20250619-r5",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5319",
-          "checksum": "sha1-JRUE7NylNCVip0FCtXFcEdUZcmI="
+          "range": "bytes=0-6055",
+          "checksum": "sha1-4ciAG6IenxrZ8zuP6H8MCcHnhaA="
         },
         "data": {
-          "range": "bytes=5320-136786",
-          "checksum": "sha256-bbwCnTVU1fkCjqugUi7Va2+2YC7HjfUJ15FLEzw4deM="
+          "range": "bytes=6056-131933",
+          "checksum": "sha256-5AeEJRnl0v4PM9/1FfMCbvk2cMz4/ed9yRmI2gP6iFw="
         },
-        "checksum": "Q1JRUE7NylNCVip0FCtXFcEdUZcmI="
+        "checksum": "Q14ciAG6IenxrZ8zuP6H8MCcHnhaA="
       },
       {
         "name": "libgcc",
-        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-14.2.0-r12.apk",
-        "version": "14.2.0-r12",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-15.2.0-r0.apk",
+        "version": "15.2.0-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5854",
-          "checksum": "sha1-HXzOXIA/woAXuF62jkq/SELUNiQ="
+          "range": "bytes=0-6108",
+          "checksum": "sha1-ae+NYzcQ2s4ShUbNcIn4JxTEBvU="
         },
         "data": {
-          "range": "bytes=5855-83420",
-          "checksum": "sha256-0rf4Mp+QMnjY0H7p3F/+Ik1lX/B2dSNA7nN67j1afMQ="
+          "range": "bytes=6109-82449",
+          "checksum": "sha256-4T/KUau24R8Ha+ixeJ9okn4/soEYkXAwcQjoos5HPQM="
         },
-        "checksum": "Q1HXzOXIA/woAXuF62jkq/SELUNiQ="
+        "checksum": "Q1ae+NYzcQ2s4ShUbNcIn4JxTEBvU="
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17803",
-          "checksum": "sha1-4wSSJr3IKkGhGt7114TYhqNTLvc="
+          "range": "bytes=0-13009",
+          "checksum": "sha1-xSvbI2Gen3c6fuysz5AB+jRNB4w="
         },
         "data": {
-          "range": "bytes=17804-568869",
-          "checksum": "sha256-P98nRN2+3Zx6SgK6A7e3bJJ6sgPjv5pkQHfoq7dsnCM="
+          "range": "bytes=13010-120775",
+          "checksum": "sha256-AnVJlyfi+UoDil9Rmj0+mk7wP29D+YKgltAppZ6/4eE="
         },
-        "checksum": "Q14wSSJr3IKkGhGt7114TYhqNTLvc="
+        "checksum": "Q1xSvbI2Gen3c6fuysz5AB+jRNB4w="
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17792",
-          "checksum": "sha1-ZrKeDj1SfcZqoJjGYnCq8xqE1uI="
+          "range": "bytes=0-12945",
+          "checksum": "sha1-PeF4sNE/zsmFusSMbZYbnq60p04="
         },
         "data": {
-          "range": "bytes=17793-93786",
-          "checksum": "sha256-BBGZ9QQHsgRa00RSo46pAcAFEgqUDDWPHMtWkSORgDQ="
+          "range": "bytes=12946-89071",
+          "checksum": "sha256-lRib43L/TCtBpRHBsFL5U2M0Hi9Pt8wAGwAposReB5w="
         },
-        "checksum": "Q1ZrKeDj1SfcZqoJjGYnCq8xqE1uI="
+        "checksum": "Q1PeF4sNE/zsmFusSMbZYbnq60p04="
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17937",
-          "checksum": "sha1-vXfsNex2s9L/Eax6Xzh6wcGMfSU="
+          "range": "bytes=0-13219",
+          "checksum": "sha1-OSa539Q3NJkY16yNFI6fuiIHbmA="
         },
         "data": {
-          "range": "bytes=17938-8425800",
-          "checksum": "sha256-OJjcb+88eVPNLAW7usB1fO3Vjg+hDfU3Bx3BVXC3D9g="
+          "range": "bytes=13220-2118025",
+          "checksum": "sha256-B5vLVtHJkthCycAh+gjgtwdeTPZ7EWlSxrzpQyMCFyM="
         },
-        "checksum": "Q1vXfsNex2s9L/Eax6Xzh6wcGMfSU="
+        "checksum": "Q1OSa539Q3NJkY16yNFI6fuiIHbmA="
       },
       {
         "name": "libxcrypt",
-        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.4.38-r1.apk",
-        "version": "4.4.38-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.4.38-r4.apk",
+        "version": "4.4.38-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7076",
-          "checksum": "sha1-i7EeMEZa76E7N+tCZDiY/B4uhs4="
+          "range": "bytes=0-6703",
+          "checksum": "sha1-rKT6keIQZNPRUjOjvtdgqc5LUdY="
         },
         "data": {
-          "range": "bytes=7077-99985",
-          "checksum": "sha256-c8nAYv/WmQi+a3RuOrPEMgjVD0+2j4UomQpHxPxB1uM="
+          "range": "bytes=6704-95241",
+          "checksum": "sha256-4d8Bv/OKk8bLzSV/mhJAkHnulhpQh1SHruDNryMvYck="
         },
-        "checksum": "Q1i7EeMEZa76E7N+tCZDiY/B4uhs4="
+        "checksum": "Q1rKT6keIQZNPRUjOjvtdgqc5LUdY="
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17827",
-          "checksum": "sha1-ux7LiQpFLvJr9BHwBeWkLCMfHzw="
+          "range": "bytes=0-12991",
+          "checksum": "sha1-5AvhwjxXWvorXLOez+bNUlzX9Z0="
         },
         "data": {
-          "range": "bytes=17828-18968",
-          "checksum": "sha256-MoMJA8U0SxqNOgx+9dTKfI9+lHraTMzXoG2/wl3AqYs="
+          "range": "bytes=12992-14272",
+          "checksum": "sha256-PAaoOTo0ceSJQCnvcu6Az066HrKryWEpJ2ZHBg6l7/s="
         },
-        "checksum": "Q1ux7LiQpFLvJr9BHwBeWkLCMfHzw="
+        "checksum": "Q15AvhwjxXWvorXLOez+bNUlzX9Z0="
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r40.apk",
-        "version": "1.37.0-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r48.apk",
+        "version": "1.37.0-r48",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6285",
-          "checksum": "sha1-gMvK6tCS0Pw0RLXpjAtSyPSNocc="
+          "range": "bytes=0-6390",
+          "checksum": "sha1-kaHpN1iTRpArTRK84g3Q+cyM478="
         },
         "data": {
-          "range": "bytes=6286-432192",
-          "checksum": "sha256-FKVvv946EX6oH5zOsTaS3AtcrXSIzjih3mYM8ajyi4g="
+          "range": "bytes=6391-425623",
+          "checksum": "sha256-VZWQA8qLD6hYCv84k6pVRJFBBk7f0vUr0fbiIArPwbY="
         },
-        "checksum": "Q1gMvK6tCS0Pw0RLXpjAtSyPSNocc="
+        "checksum": "Q1kaHpN1iTRpArTRK84g3Q+cyM478="
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8964",
-          "checksum": "sha1-S5Ad/WGF3WLici60SrCB1YYsLZE="
+          "range": "bytes=0-9099",
+          "checksum": "sha1-GoUojkaCyWJgmuiKsHvN/dDcCGw="
         },
         "data": {
-          "range": "bytes=8965-2159527",
-          "checksum": "sha256-dVnzX3EnJPMRWrN1JIGZ+bqGQRO3Oka2rKCrNW8gIJ8="
+          "range": "bytes=9100-2138928",
+          "checksum": "sha256-3YCbzj87t4sd1akgNQhsI/SSKZv3iwWUoAHX00lx/68="
         },
-        "checksum": "Q1S5Ad/WGF3WLici60SrCB1YYsLZE="
+        "checksum": "Q1GoUojkaCyWJgmuiKsHvN/dDcCGw="
       },
       {
         "name": "ca-certificates",
-        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-20241121-r40.apk",
-        "version": "20241121-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-20250619-r5.apk",
+        "version": "20250619-r5",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5366",
-          "checksum": "sha1-n5x9KFDurVt5aeM2kOaWJp9JTfY="
+          "range": "bytes=0-6116",
+          "checksum": "sha1-JXlPDDhe1O50X9K+eze3h4yoNss="
         },
         "data": {
-          "range": "bytes=5367-172422",
-          "checksum": "sha256-20OycKDpT3Tyvp+iozvuLMThwlGzmkbDUOwPK+MfCRk="
+          "range": "bytes=6117-167254",
+          "checksum": "sha256-ygNS1URrtVWGqwtgm00PhNEWtK0BzmbEeT3ENJAetXg="
         },
-        "checksum": "Q1n5x9KFDurVt5aeM2kOaWJp9JTfY="
+        "checksum": "Q1JXlPDDhe1O50X9K+eze3h4yoNss="
       },
       {
         "name": "chainctl",
-        "url": "https://packages.cgr.dev/extras/aarch64/chainctl-0.2.76-r0.apk",
-        "version": "0.2.76-r0",
+        "url": "https://packages.cgr.dev/extras/aarch64/chainctl-0.2.121-r0.apk",
+        "version": "0.2.121-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1693",
-          "checksum": "sha1-LAVMG6g+PyVH6oepRILejXJAYqM="
+          "range": "bytes=0-1698",
+          "checksum": "sha1-XiSAghqKRKdwrMdOujXvaeXuwao="
         },
         "data": {
-          "range": "bytes=1694-22205080",
-          "checksum": "sha256-mA7Z0EajDvOkdTJcAiUPey9cpo20mR12EsrpVYsHj0c="
+          "range": "bytes=1699-28640996",
+          "checksum": "sha256-0LFX0yhbP32T8vx69pyBXIVrXY/z/YYRmpwiv4gI4F8="
         },
-        "checksum": "Q1LAVMG6g+PyVH6oepRILejXJAYqM="
+        "checksum": "Q1XiSAghqKRKdwrMdOujXvaeXuwao="
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.1-r6.apk",
-        "version": "1.3.1-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.1-r51.apk",
+        "version": "1.3.1-r51",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8190",
-          "checksum": "sha1-KioZgEzEWwIOgnFfsOtwFMj61rI="
+          "range": "bytes=0-7324",
+          "checksum": "sha1-tsMFsix2JCqVx/gQd+2yCWxJYSU="
         },
         "data": {
-          "range": "bytes=8191-57550",
-          "checksum": "sha256-VjrCUoUoqKcAEGBptxtQlq6DeGE5LwTHgPYwEnrR6Uw="
+          "range": "bytes=7325-56968",
+          "checksum": "sha256-jASYiEAr7PdGaa+2YwD6gtrSOcUkUh+UZ5I7IQShGQA="
         },
-        "checksum": "Q1KioZgEzEWwIOgnFfsOtwFMj61rI="
+        "checksum": "Q1tsMFsix2JCqVx/gQd+2yCWxJYSU="
       },
       {
         "name": "libunistring",
-        "url": "https://packages.wolfi.dev/os/aarch64/libunistring-1.3-r1.apk",
-        "version": "1.3-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libunistring-1.3-r4.apk",
+        "version": "1.3-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-404",
-          "checksum": "sha1-h3xCrpiyNA2+FbaJ12gV9e3uo+o="
+          "range": "bytes=0-3845",
+          "checksum": "sha1-oCNGn37D/pqTWLt7hKN4uSNMvuc="
         },
         "data": {
-          "range": "bytes=405-951140",
-          "checksum": "sha256-Fd2o+zAE1klnIAjGqaoLBK4imP80fBmium07cPmwq9M="
+          "range": "bytes=3846-948190",
+          "checksum": "sha256-fQs90yweNpqGMFeJ4bhgOxXLB/hPuMrS6qjUIAqpLI0="
         },
-        "checksum": "Q1h3xCrpiyNA2+FbaJ12gV9e3uo+o="
+        "checksum": "Q1oCNGn37D/pqTWLt7hKN4uSNMvuc="
       },
       {
         "name": "libidn2",
-        "url": "https://packages.wolfi.dev/os/aarch64/libidn2-2.3.8-r0.apk",
-        "version": "2.3.8-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libidn2-2.3.8-r3.apk",
+        "version": "2.3.8-r3",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5193",
-          "checksum": "sha1-b0KmAUcWAjoYR/G7yLUpVjuui4k="
+          "range": "bytes=0-4197",
+          "checksum": "sha1-ISuOUOdq3A+qFVAiYvQfNi0Nhu8="
         },
         "data": {
-          "range": "bytes=5194-131370",
-          "checksum": "sha256-PWOCCEbg4XTKp6jVmpjDt1Tqmx3zWFGPPq1a2ULq/MY="
+          "range": "bytes=4198-130238",
+          "checksum": "sha256-SCi7XF5j7Cw1o19r+rVpteLdMHP79juIOo9q8+b+LHM="
         },
-        "checksum": "Q1b0KmAUcWAjoYR/G7yLUpVjuui4k="
+        "checksum": "Q1ISuOUOdq3A+qFVAiYvQfNi0Nhu8="
       },
       {
         "name": "libpsl",
-        "url": "https://packages.wolfi.dev/os/aarch64/libpsl-0.21.5-r4.apk",
-        "version": "0.21.5-r4",
+        "url": "https://packages.wolfi.dev/os/aarch64/libpsl-0.21.5-r6.apk",
+        "version": "0.21.5-r6",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-391",
-          "checksum": "sha1-b5f3NanzE7dwPf2MI1yEb/TMfwg="
+          "range": "bytes=0-6153",
+          "checksum": "sha1-vEsSKiRV23mLp81cpY4fpJoHHNU="
         },
         "data": {
-          "range": "bytes=392-61910",
-          "checksum": "sha256-NItF73gzyVDzQDEBJCUoxdCqlo0grzFb9Jj/4z84B1M="
+          "range": "bytes=6154-67497",
+          "checksum": "sha256-5EKbmJjrR30Y6iAg301fdB3rGtPIBgAtAB5VW4ohWhQ="
         },
-        "checksum": "Q1b5f3NanzE7dwPf2MI1yEb/TMfwg="
+        "checksum": "Q1vEsSKiRV23mLp81cpY4fpJoHHNU="
       },
       {
         "name": "libbrotlicommon1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlicommon1-1.1.0-r4.apk",
-        "version": "1.1.0-r4",
+        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlicommon1-1.1.0-r7.apk",
+        "version": "1.1.0-r7",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-698",
-          "checksum": "sha1-1aO3mkS/i7/IEe7oYBoC1zXMoaQ="
+          "range": "",
+          "checksum": ""
         },
         "control": {
-          "range": "bytes=699-1041",
-          "checksum": "sha1-/1YGM7es4YaF75g2/cKj76cPumg="
+          "range": "bytes=0-5666",
+          "checksum": "sha1-riBtRBnWPbig7pmFBkq3FBcqWa0="
         },
         "data": {
-          "range": "bytes=1042-70313",
-          "checksum": "sha256-NaiFzDfOmpZnsWp8pZShCiXpG6z9ER0THlMGubjp0GY="
+          "range": "bytes=5667-75908",
+          "checksum": "sha256-FAmX+fbDpu04F06s/7WrEj9jv4TiCANT8ofArLP2WSE="
         },
-        "checksum": "Q1/1YGM7es4YaF75g2/cKj76cPumg="
+        "checksum": "Q1riBtRBnWPbig7pmFBkq3FBcqWa0="
       },
       {
         "name": "libbrotlidec1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlidec1-1.1.0-r4.apk",
-        "version": "1.1.0-r4",
+        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlidec1-1.1.0-r7.apk",
+        "version": "1.1.0-r7",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-698",
-          "checksum": "sha1-/08OgTILJ66OJ4sHK5blHbqE60A="
+          "range": "",
+          "checksum": ""
         },
         "control": {
-          "range": "bytes=699-1058",
-          "checksum": "sha1-i/GC/PqSNMH2TtEsESOeITF8MKo="
+          "range": "bytes=0-5681",
+          "checksum": "sha1-RvoBzvKrleDAvW1yQ9CVLJpfQNA="
         },
         "data": {
-          "range": "bytes=1059-25422",
-          "checksum": "sha256-AY1Ca0Kf0cYrkDh9rFWvdepfBFyGjwDAINPM/zzdb68="
+          "range": "bytes=5682-35152",
+          "checksum": "sha256-+W1+aTZ5MQefc38NMHJl9koi7UKgG/aySZmHGi37+CI="
         },
-        "checksum": "Q1i/GC/PqSNMH2TtEsESOeITF8MKo="
+        "checksum": "Q1RvoBzvKrleDAvW1yQ9CVLJpfQNA="
       },
       {
         "name": "libverto",
-        "url": "https://packages.wolfi.dev/os/aarch64/libverto-0.3.2-r4.apk",
-        "version": "0.3.2-r4",
+        "url": "https://packages.wolfi.dev/os/aarch64/libverto-0.3.2-r6.apk",
+        "version": "0.3.2-r6",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-692",
-          "checksum": "sha1-JOZf/QOnwzEp/tguqWEGARoNtwo="
+          "range": "",
+          "checksum": ""
         },
         "control": {
-          "range": "bytes=693-1062",
-          "checksum": "sha1-SBCuBBnyqfUcaFmylRReCe55U9g="
+          "range": "bytes=0-5971",
+          "checksum": "sha1-eN0T+PDmeRULUDXDAj08AHHMIbU="
         },
         "data": {
-          "range": "bytes=1063-13592",
-          "checksum": "sha256-7zQkxbzevaVmPalAwJRRWFf3/QaPycSvinbkgPSS6JM="
+          "range": "bytes=5972-19148",
+          "checksum": "sha256-eysA8zipY/mRoyGsRKtyaK1cTdJlbwEC+y0zkRQOsHA="
         },
-        "checksum": "Q1SBCuBBnyqfUcaFmylRReCe55U9g="
+        "checksum": "Q1eN0T+PDmeRULUDXDAj08AHHMIbU="
       },
       {
         "name": "krb5-conf",
-        "url": "https://packages.wolfi.dev/os/aarch64/krb5-conf-1.0-r5.apk",
-        "version": "1.0-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/krb5-conf-1.0-r7.apk",
+        "version": "1.0-r7",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1035",
-          "checksum": "sha1-KtYTM1ncFmmQ7n2XN9dqywwumEU="
+          "range": "bytes=0-1054",
+          "checksum": "sha1-Ssz5TYkFUK3StyDa0/ONF0cTWMM="
         },
         "data": {
-          "range": "bytes=1036-2341",
-          "checksum": "sha256-r01nz54toQB4Cy6NMZvfBR/X2tADyCVg16h+qsfqHLQ="
+          "range": "bytes=1055-2423",
+          "checksum": "sha256-zyePIYw78R7K4EtWR+15q7LXBAn8iQOe9mkjWPL55tA="
         },
-        "checksum": "Q1KtYTM1ncFmmQ7n2XN9dqywwumEU="
+        "checksum": "Q1Ssz5TYkFUK3StyDa0/ONF0cTWMM="
       },
       {
         "name": "libcom_err",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcom_err-1.47.2-r21.apk",
-        "version": "1.47.2-r21",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcom_err-1.47.3-r1.apk",
+        "version": "1.47.3-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7712",
-          "checksum": "sha1-wyidJBDhBhhzuliXpZ7q3piuWUg="
+          "range": "bytes=0-7345",
+          "checksum": "sha1-cJWg0MdEhNxPe7qzDSFVBSzX+OQ="
         },
         "data": {
-          "range": "bytes=7713-16121",
-          "checksum": "sha256-7t8/GrkcRTlwE+zPJOL7oSG//L0kLQQ6CHfIJIniTfg="
+          "range": "bytes=7346-16029",
+          "checksum": "sha256-Ham9OyqKl5J+I/7Vjsp1l06QKHYkafQVbI9fH3qNlr4="
         },
-        "checksum": "Q1wyidJBDhBhhzuliXpZ7q3piuWUg="
+        "checksum": "Q1cJWg0MdEhNxPe7qzDSFVBSzX+OQ="
       },
       {
         "name": "keyutils-libs",
-        "url": "https://packages.wolfi.dev/os/aarch64/keyutils-libs-1.6.3-r31.apk",
-        "version": "1.6.3-r31",
+        "url": "https://packages.wolfi.dev/os/aarch64/keyutils-libs-1.6.3-r37.apk",
+        "version": "1.6.3-r37",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6997",
-          "checksum": "sha1-ACEcCOZ1DMbTZbPD+q/aTrxW/74="
+          "range": "bytes=0-6630",
+          "checksum": "sha1-g+c4M4bhURUt6WZSXBvOS61E8m4="
         },
         "data": {
-          "range": "bytes=6998-17762",
-          "checksum": "sha256-B+ZNxxIJvab6umH1vZ3ZMw0podvKEv72MCrxX1SXU/U="
+          "range": "bytes=6631-17712",
+          "checksum": "sha256-sMrpa3MCefx42prqS0d/hsUQcmEA7g+cHWYGh/joiqo="
         },
-        "checksum": "Q1ACEcCOZ1DMbTZbPD+q/aTrxW/74="
+        "checksum": "Q1g+c4M4bhURUt6WZSXBvOS61E8m4="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8966",
-          "checksum": "sha1-vwslUX45jLscd5Hhf6ZuoNnGRfM="
+          "range": "bytes=0-9098",
+          "checksum": "sha1-INRxoI0GWtbnXLVpUzTIaI1jt2s="
         },
         "data": {
-          "range": "bytes=8967-480947",
-          "checksum": "sha256-Ta/BersmN7IocKvjwRv4JhkX7mAXzKqWErlWxjKKnu4="
+          "range": "bytes=9099-481348",
+          "checksum": "sha256-imcvx13ksizOkEspSC39rujmac4j4NRqjjF2FDS5900="
         },
-        "checksum": "Q1vwslUX45jLscd5Hhf6ZuoNnGRfM="
+        "checksum": "Q1INRxoI0GWtbnXLVpUzTIaI1jt2s="
       },
       {
         "name": "krb5-libs",
-        "url": "https://packages.wolfi.dev/os/aarch64/krb5-libs-1.21.3-r40.apk",
-        "version": "1.21.3-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/krb5-libs-1.22-r2.apk",
+        "version": "1.22-r2",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6946",
-          "checksum": "sha1-0uzEbqJX32r4EaJcjyZ+o0TyKYM="
+          "range": "bytes=0-7869",
+          "checksum": "sha1-LYoJt7S2XBcRKUJXQK7vyi0e8Zs="
         },
         "data": {
-          "range": "bytes=6947-1048287",
-          "checksum": "sha256-w9dB4/Lxu8BxUNxVIuXdP8IeWu5oYDUxl4kdyHee2zQ="
+          "range": "bytes=7870-1067388",
+          "checksum": "sha256-K9UhBEoutl4wkU8atVxJemt/pV0g6qpVShDifkgXexk="
         },
-        "checksum": "Q10uzEbqJX32r4EaJcjyZ+o0TyKYM="
+        "checksum": "Q1LYoJt7S2XBcRKUJXQK7vyi0e8Zs="
       },
       {
         "name": "ncurses-terminfo-base",
-        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-terminfo-base-6.5_p20241228-r1.apk",
-        "version": "6.5_p20241228-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-terminfo-base-6.5_p20250621-r1.apk",
+        "version": "6.5_p20250621-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6024",
-          "checksum": "sha1-KqW0ALTFBpRCA7etxzZAIQrvmFQ="
+          "range": "bytes=0-4646",
+          "checksum": "sha1-CNi4eaQ3qBJg3rJ108SnlcV6pN8="
         },
         "data": {
-          "range": "bytes=6025-104062",
-          "checksum": "sha256-KZ5ZQthGfCsgtjNjyAQT4QTR3MpixX282pwGgpdQIMc="
+          "range": "bytes=4647-106092",
+          "checksum": "sha256-Stn7X+JWk7Cw3otoKwhBTjJcnfZMDFUk4VpEUObrtjA="
         },
-        "checksum": "Q1KqW0ALTFBpRCA7etxzZAIQrvmFQ="
+        "checksum": "Q1CNi4eaQ3qBJg3rJ108SnlcV6pN8="
       },
       {
         "name": "ncurses",
-        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-6.5_p20241228-r1.apk",
-        "version": "6.5_p20241228-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-6.5_p20250621-r1.apk",
+        "version": "6.5_p20250621-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6112",
-          "checksum": "sha1-yr5UL6LOuV7UmM+tdckSfn5wekU="
+          "range": "bytes=0-4765",
+          "checksum": "sha1-0B26hyojosFIo9p+XD4gNGVI3Rc="
         },
         "data": {
-          "range": "bytes=6113-448161",
-          "checksum": "sha256-695KQTX2tQ+fG+H++n+IFvVVd4HXrkKN9cP+DHlImR8="
+          "range": "bytes=4766-449341",
+          "checksum": "sha256-UTB9b8UpWXRY37dKl8fFA8UsbGAEA8arJ0iGsYmwssE="
         },
-        "checksum": "Q1yr5UL6LOuV7UmM+tdckSfn5wekU="
+        "checksum": "Q10B26hyojosFIo9p+XD4gNGVI3Rc="
       },
       {
         "name": "readline",
-        "url": "https://packages.wolfi.dev/os/aarch64/readline-8.2.13-r3.apk",
-        "version": "8.2.13-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/readline-8.3-r1.apk",
+        "version": "8.3-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4041",
-          "checksum": "sha1-E2bZtzRGqjzn4rDYC6kR8I8w13g="
+          "range": "bytes=0-3933",
+          "checksum": "sha1-U8GDjvDj9eHCB+1NdgXp4NKzmPE="
         },
         "data": {
-          "range": "bytes=4042-317613",
-          "checksum": "sha256-RUOO/Loj44NGaAYv31RIA3dOZ3nlKnWZcyibYX1sYPw="
+          "range": "bytes=3934-335034",
+          "checksum": "sha256-PU16uzdKxlk7V28YHwwE6EgxQfcPeQdbqV4nrD0wyC0="
         },
-        "checksum": "Q1E2bZtzRGqjzn4rDYC6kR8I8w13g="
+        "checksum": "Q1U8GDjvDj9eHCB+1NdgXp4NKzmPE="
       },
       {
         "name": "sqlite-libs",
-        "url": "https://packages.wolfi.dev/os/aarch64/sqlite-libs-3.49.2-r0.apk",
-        "version": "3.49.2-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/sqlite-libs-3.50.4-r0.apk",
+        "version": "3.50.4-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4348",
-          "checksum": "sha1-LzP/6RmgSWz2p1PVa/4fdX6h+KI="
+          "range": "bytes=0-4430",
+          "checksum": "sha1-GE14+ba8ahwuMCr0mpSDbUEpvJ4="
         },
         "data": {
-          "range": "bytes=4349-865827",
-          "checksum": "sha256-IZ9d0oDTxw84/zaXaAFvTnC3WUzIxIK6dnG+2dnIQVU="
+          "range": "bytes=4431-870078",
+          "checksum": "sha256-7P7LiMfOXJqbUnHVJAbxapCxRTzaXZGyd06fzLrKTFg="
         },
-        "checksum": "Q1LzP/6RmgSWz2p1PVa/4fdX6h+KI="
+        "checksum": "Q1GE14+ba8ahwuMCr0mpSDbUEpvJ4="
       },
       {
         "name": "heimdal-libs",
-        "url": "https://packages.wolfi.dev/os/aarch64/heimdal-libs-7.8.0-r40.apk",
-        "version": "7.8.0-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/heimdal-libs-7.8.0-r42.apk",
+        "version": "7.8.0-r42",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4969",
-          "checksum": "sha1-b3wC0L5i/XdD7QxjAch8uPNrDNM="
+          "range": "bytes=0-5167",
+          "checksum": "sha1-4kY5hwnCpudVxfeCY4jW67u+yro="
         },
         "data": {
-          "range": "bytes=4970-1426114",
-          "checksum": "sha256-RPhsi8b6+v0zMH5dv8+FNoHeTW+W1nstPZbrolowtSg="
+          "range": "bytes=5168-1429464",
+          "checksum": "sha256-Jmw2vANc/XxzA1RXbD35wT3c4zBny8b+OeIOOocykLI="
         },
-        "checksum": "Q1b3wC0L5i/XdD7QxjAch8uPNrDNM="
+        "checksum": "Q14kY5hwnCpudVxfeCY4jW67u+yro="
       },
       {
         "name": "gdbm",
-        "url": "https://packages.wolfi.dev/os/aarch64/gdbm-1.25-r0.apk",
-        "version": "1.25-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/gdbm-1.26-r1.apk",
+        "version": "1.26-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-3531",
-          "checksum": "sha1-ErrkP7/b9z06U3aQ0NvWc7+104Q="
+          "range": "bytes=0-4336",
+          "checksum": "sha1-OUORz/SIO9lrZBhqTbh5oYed1EY="
         },
         "data": {
-          "range": "bytes=3532-256323",
-          "checksum": "sha256-kNYuPXc0qHYjbvhAZrZ58MvZVS2OEQXsnxSYgibmR0Q="
+          "range": "bytes=4337-258396",
+          "checksum": "sha256-2CMAwQ1McxnIuGBtrQRQ66YMOCbhyrvdeHaBMKW1ytg="
         },
-        "checksum": "Q1ErrkP7/b9z06U3aQ0NvWc7+104Q="
+        "checksum": "Q1OUORz/SIO9lrZBhqTbh5oYed1EY="
       },
       {
         "name": "cyrus-sasl",
-        "url": "https://packages.wolfi.dev/os/aarch64/cyrus-sasl-2.1.28-r40.apk",
-        "version": "2.1.28-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/cyrus-sasl-2.1.28-r44.apk",
+        "version": "2.1.28-r44",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6416",
-          "checksum": "sha1-V3+mvJZ5+jIetrzeXhJWyclKOro="
+          "range": "bytes=0-7343",
+          "checksum": "sha1-Z43p4A4DHrBiRSMluWzHmII31XU="
         },
         "data": {
-          "range": "bytes=6417-325595",
-          "checksum": "sha256-zTthy7jHtfNi6hvbKlyRkO2U3BnKrFxyUUVGmhOF4Gg="
+          "range": "bytes=7344-307622",
+          "checksum": "sha256-4TMIXoxkAWqvGdR4XQ70fAJkuYUOEzZwXcGQQyzkudg="
         },
-        "checksum": "Q1V3+mvJZ5+jIetrzeXhJWyclKOro="
+        "checksum": "Q1Z43p4A4DHrBiRSMluWzHmII31XU="
       },
       {
         "name": "libldap",
-        "url": "https://packages.wolfi.dev/os/aarch64/libldap-2.6.9-r41.apk",
-        "version": "2.6.9-r41",
+        "url": "https://packages.wolfi.dev/os/aarch64/libldap-2.6.10-r5.apk",
+        "version": "2.6.10-r5",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-9563",
-          "checksum": "sha1-OhMFb0tIbYY60SgkjssAvwj4nxM="
+          "range": "bytes=0-9687",
+          "checksum": "sha1-40OwOFcYvCxenYeed5V4xfo07v8="
         },
         "data": {
-          "range": "bytes=9564-242411",
-          "checksum": "sha256-/mMrZKT+zdG+UKUwS7lH5TvBJ7xSYIEHZptykBHNXV8="
+          "range": "bytes=9688-240815",
+          "checksum": "sha256-1HPW/HGP9IAVLoh+f/ePTwt8MqMYYvYoyTFnsbtGgnA="
         },
-        "checksum": "Q1OhMFb0tIbYY60SgkjssAvwj4nxM="
+        "checksum": "Q140OwOFcYvCxenYeed5V4xfo07v8="
       },
       {
         "name": "libnghttp2-14",
-        "url": "https://packages.wolfi.dev/os/aarch64/libnghttp2-14-1.65.0-r0.apk",
-        "version": "1.65.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libnghttp2-14-1.66.0-r1.apk",
+        "version": "1.66.0-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7089",
-          "checksum": "sha1-0lqAU3u0YiuGvr7EGanNY0nUFEE="
+          "range": "bytes=0-6129",
+          "checksum": "sha1-oKUQ1kFDkWmmRrhMFerTY/YJ68k="
         },
         "data": {
-          "range": "bytes=7090-103932",
-          "checksum": "sha256-yIzAjsn5nfBEpc/RdLQljEDcBZJhebcRQInDujtXMQA="
+          "range": "bytes=6130-102706",
+          "checksum": "sha256-yzwFGC9AVYeEGoztBkkPLDik8lJyMGy+DYt4HtZxCWg="
         },
-        "checksum": "Q10lqAU3u0YiuGvr7EGanNY0nUFEE="
+        "checksum": "Q1oKUQ1kFDkWmmRrhMFerTY/YJ68k="
       },
       {
         "name": "libcurl-openssl4",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcurl-openssl4-8.13.0-r0.apk",
-        "version": "8.13.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcurl-openssl4-8.15.0-r4.apk",
+        "version": "8.15.0-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4954",
-          "checksum": "sha1-beppZPRxn7X0tXZLGzejhgmZjuY="
+          "range": "bytes=0-7413",
+          "checksum": "sha1-3hyggIBESg7WKe5ksHc7/Cd3C28="
         },
         "data": {
-          "range": "bytes=4955-451317",
-          "checksum": "sha256-CENxtESc0m/3F6e7+cg86sy/WsHDuLQn2UQJtwUZ8A0="
+          "range": "bytes=7414-474624",
+          "checksum": "sha256-Lu6/8ZfBf4G4e12GmritCraH7WHPSKzAoS5TeWMWb2w="
         },
-        "checksum": "Q1beppZPRxn7X0tXZLGzejhgmZjuY="
+        "checksum": "Q13hyggIBESg7WKe5ksHc7/Cd3C28="
       },
       {
         "name": "curl",
@@ -706,60 +706,60 @@
       },
       {
         "name": "libpcre2-8-0",
-        "url": "https://packages.wolfi.dev/os/aarch64/libpcre2-8-0-10.45-r1.apk",
-        "version": "10.45-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libpcre2-8-0-10.45-r3.apk",
+        "version": "10.45-r3",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7963",
-          "checksum": "sha1-Nplh6AtMNT4poynfP7QeG82JYTg="
+          "range": "bytes=0-6750",
+          "checksum": "sha1-n71il6sD5NHxmF3Z6f9m+zQwF5A="
         },
         "data": {
-          "range": "bytes=7964-284510",
-          "checksum": "sha256-/4x9YTl9G1QAFZbBOU+xHhXtOF2I2POoOESBplXPz/E="
+          "range": "bytes=6751-279857",
+          "checksum": "sha256-ulp0TL2SrP9CH6S5JscIbpx0FfrW506ed52Z3k7vTHo="
         },
-        "checksum": "Q1Nplh6AtMNT4poynfP7QeG82JYTg="
+        "checksum": "Q1n71il6sD5NHxmF3Z6f9m+zQwF5A="
       },
       {
         "name": "libexpat1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libexpat1-2.7.1-r0.apk",
-        "version": "2.7.1-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libexpat1-2.7.1-r3.apk",
+        "version": "2.7.1-r3",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4225",
-          "checksum": "sha1-wccUrioLXohuoA/K909Wnp3t0jU="
+          "range": "bytes=0-5020",
+          "checksum": "sha1-DpPQ4uCfu45PbiRF1TvH1fS4yPw="
         },
         "data": {
-          "range": "bytes=4226-82039",
-          "checksum": "sha256-KFTE5zKz29je/EtS2UNS9GsxRS7qGJtvuufAq3e6YiU="
+          "range": "bytes=5021-83300",
+          "checksum": "sha256-fPt279oX4V1DJ6VBbde/d3NLNlp9ZVkn0aZjymt7l0w="
         },
-        "checksum": "Q1wccUrioLXohuoA/K909Wnp3t0jU="
+        "checksum": "Q1DpPQ4uCfu45PbiRF1TvH1fS4yPw="
       },
       {
         "name": "git",
-        "url": "https://packages.wolfi.dev/os/aarch64/git-2.49.0-r1.apk",
-        "version": "2.49.0-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/git-2.50.1-r1.apk",
+        "version": "2.50.1-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5549",
-          "checksum": "sha1-Z1gS7WjECsAi2uMNphgGu2+8zZE="
+          "range": "bytes=0-9521",
+          "checksum": "sha1-1JJRDx1D0jiZxhhw4rYSPOAo9R4="
         },
         "data": {
-          "range": "bytes=5550-9102138",
-          "checksum": "sha256-43PbsoM8vaobDaCjng5lLa0fatifqWs3KHvlmHcvdso="
+          "range": "bytes=9522-8871121",
+          "checksum": "sha256-sOVA2TvQa7bR/pZkb5XNXEkbo4dTti7X73WUMyk1gXY="
         },
-        "checksum": "Q1Z1gS7WjECsAi2uMNphgGu2+8zZE="
+        "checksum": "Q11JJRDx1D0jiZxhhw4rYSPOAo9R4="
       },
       {
         "name": "oniguruma",
@@ -782,915 +782,915 @@
       },
       {
         "name": "jq",
-        "url": "https://packages.wolfi.dev/os/aarch64/jq-1.7.1-r5.apk",
-        "version": "1.7.1-r5",
+        "url": "https://packages.wolfi.dev/os/aarch64/jq-1.8.1-r2.apk",
+        "version": "1.8.1-r2",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6462",
-          "checksum": "sha1-nZj7Wi/apmXMr2//2b/X4bFeq4Y="
+          "range": "bytes=0-7036",
+          "checksum": "sha1-les0aFJAp1fSYGZ5mzEJ0L8FmwA="
         },
         "data": {
-          "range": "bytes=6463-395301",
-          "checksum": "sha256-kwyYPpdYDFPoIO5N3wfm9x5BYuxqheBfLdmtbcW/iiE="
+          "range": "bytes=7037-226764",
+          "checksum": "sha256-2/o4SzLSgKnNSg9kCVhhDl0I2qSIMc5aJlVnafql23c="
         },
-        "checksum": "Q1nZj7Wi/apmXMr2//2b/X4bFeq4Y="
+        "checksum": "Q1les0aFJAp1fSYGZ5mzEJ0L8FmwA="
       },
       {
         "name": "less",
-        "url": "https://packages.wolfi.dev/os/aarch64/less-678-r0.apk",
-        "version": "678-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/less-681-r1.apk",
+        "version": "681-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5103",
-          "checksum": "sha1-PSpRjDeEZmdfNQ8vI7ntkwrLFq8="
+          "range": "bytes=0-5846",
+          "checksum": "sha1-kGk/gs3WLx1/5rkf2c/14GG+q4A="
         },
         "data": {
-          "range": "bytes=5104-164652",
-          "checksum": "sha256-uchmujTCFXKCAWjx5u4b6/wlymVdreoLbZCF2YzWHzg="
+          "range": "bytes=5847-165447",
+          "checksum": "sha256-88u4RF+U2bzQI1EREYCWPbo3LOAzROKEV852xsuuoYE="
         },
-        "checksum": "Q1PSpRjDeEZmdfNQ8vI7ntkwrLFq8="
+        "checksum": "Q1kGk/gs3WLx1/5rkf2c/14GG+q4A="
       },
       {
         "name": "libedit",
-        "url": "https://packages.wolfi.dev/os/aarch64/libedit-3.1-r8.apk",
-        "version": "3.1-r8",
+        "url": "https://packages.wolfi.dev/os/aarch64/libedit-3.1-r13.apk",
+        "version": "3.1-r13",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-3911",
-          "checksum": "sha1-WCuZeF69Ut7AfK5QaMRxOnpO2mI="
+          "range": "bytes=0-4735",
+          "checksum": "sha1-5OK8cUWgK+AAymX470y2JuS5+mQ="
         },
         "data": {
-          "range": "bytes=3912-115592",
-          "checksum": "sha256-Ed1/t0olEcVWZNS/dFSoUe/JXi8fUNWVN6iRarzJ6ak="
+          "range": "bytes=4736-116648",
+          "checksum": "sha256-xQN+0p1v3uSY3aj0gp6hUqro3FEvyMlWxeRUArQhybk="
         },
-        "checksum": "Q1WCuZeF69Ut7AfK5QaMRxOnpO2mI="
+        "checksum": "Q15OK8cUWgK+AAymX470y2JuS5+mQ="
       },
       {
         "name": "openssh-client",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssh-client-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssh-client-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4793",
-          "checksum": "sha1-caLtizpMsKh5kNmZvdbhHFTKIQw="
+          "range": "bytes=0-4892",
+          "checksum": "sha1-i2Za1Wj3yW9iIyoBmUMg50S2ieQ="
         },
         "data": {
-          "range": "bytes=4794-1143363",
-          "checksum": "sha256-uk/9asCG98WQjSZOtPoF/K2RXmu5Nc8z07ga5V/fwCo="
+          "range": "bytes=4893-1129896",
+          "checksum": "sha256-Qx2wSvWrvf2Y9RhiQNpI44tYCeiz1QC5TKfqdK1szig="
         },
-        "checksum": "Q1caLtizpMsKh5kNmZvdbhHFTKIQw="
+        "checksum": "Q1i2Za1Wj3yW9iIyoBmUMg50S2ieQ="
       },
       {
         "name": "libsepol",
-        "url": "https://packages.wolfi.dev/os/aarch64/libsepol-3.8.1-r2.apk",
-        "version": "3.8.1-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/libsepol-3.9-r1.apk",
+        "version": "3.9-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5035",
-          "checksum": "sha1-xZtC8Vsvd4UOXg5mom0pbTr17hg="
+          "range": "bytes=0-5187",
+          "checksum": "sha1-W1e8Dqys/Al8FHmuCo/tZQfatqo="
         },
         "data": {
-          "range": "bytes=5036-444843",
-          "checksum": "sha256-Hy2A5BlloT++DPf4PvqhJcTc6NinP+l3fFP0foEC8qs="
+          "range": "bytes=5188-445502",
+          "checksum": "sha256-SJm4ROFqiLK4eN//YaGQ5QuPRzsglMcvhfHRpUhVovc="
         },
-        "checksum": "Q1xZtC8Vsvd4UOXg5mom0pbTr17hg="
+        "checksum": "Q1W1e8Dqys/Al8FHmuCo/tZQfatqo="
       },
       {
         "name": "libselinux",
-        "url": "https://packages.wolfi.dev/os/aarch64/libselinux-3.8.1-r40.apk",
-        "version": "3.8.1-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/libselinux-3.9-r1.apk",
+        "version": "3.9-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6460",
-          "checksum": "sha1-OFCyfnJ78+acqN6KWwUSfGI1uz4="
+          "range": "bytes=0-6552",
+          "checksum": "sha1-qhmA0X7jLkalwYAfZHC+sND16i4="
         },
         "data": {
-          "range": "bytes=6461-422096",
-          "checksum": "sha256-BCupvzpQnXMHs+XsPjSMRhGAZSja5UUe34Bj15C7D1o="
+          "range": "bytes=6553-428681",
+          "checksum": "sha256-jmZNslAoq66MpyKXOxy4h55kcLPaH2tkzrWweAAIE0c="
         },
-        "checksum": "Q1OFCyfnJ78+acqN6KWwUSfGI1uz4="
+        "checksum": "Q1qhmA0X7jLkalwYAfZHC+sND16i4="
       },
       {
         "name": "linux-pam",
-        "url": "https://packages.wolfi.dev/os/aarch64/linux-pam-1.7.0-r40.apk",
-        "version": "1.7.0-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/linux-pam-1.7.1-r1.apk",
+        "version": "1.7.1-r1",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-3829",
-          "checksum": "sha1-+/PLNuf2jm3bKKPrQOODLllYg7g="
+          "range": "bytes=0-3942",
+          "checksum": "sha1-bwFpSsgCxNOvZPdN7Dq+10WVlKs="
         },
         "data": {
-          "range": "bytes=3830-933952",
-          "checksum": "sha256-qMNP+2jF3amQ8k/ujeRWWSAY07hEasBifwShPRhsLK0="
+          "range": "bytes=3943-955783",
+          "checksum": "sha256-cWEbqp05JAxqtWE4+Hp+92iIb7qSL+pg6X0eJ5u48tk="
         },
-        "checksum": "Q1+/PLNuf2jm3bKKPrQOODLllYg7g="
+        "checksum": "Q1bwFpSsgCxNOvZPdN7Dq+10WVlKs="
       },
       {
         "name": "openssh-server-config",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssh-server-config-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssh-server-config-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4723",
-          "checksum": "sha1-7av5ru2yDW3kA5/B3ZaDRZ4YnHg="
+          "range": "bytes=0-4818",
+          "checksum": "sha1-tMc4Ud1FP13AK+q3Nnf2ZNBXPpg="
         },
         "data": {
-          "range": "bytes=4724-7564",
-          "checksum": "sha256-fpNox2sRWb8B6A6m+1El/I5eQpgA6EZ1kWwJuKTi/10="
+          "range": "bytes=4819-7781",
+          "checksum": "sha256-BffcBYUOWb2aBR4+e3nAHsXKm2+8WOs+8MxFGUvcHsE="
         },
-        "checksum": "Q17av5ru2yDW3kA5/B3ZaDRZ4YnHg="
+        "checksum": "Q1tMc4Ud1FP13AK+q3Nnf2ZNBXPpg="
       },
       {
         "name": "openssh-keygen",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssh-keygen-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssh-keygen-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4767",
-          "checksum": "sha1-NkEgltHxH7K57K6lLQvJS3MrBaQ="
+          "range": "bytes=0-4864",
+          "checksum": "sha1-5xWfLjHv2pnAj/oWRzXeczLiN5E="
         },
         "data": {
-          "range": "bytes=4768-268489",
-          "checksum": "sha256-n1zJeZulQZcFSXLKeCn2fTDFJYDJlgcbocSmcFon7jo="
+          "range": "bytes=4865-265887",
+          "checksum": "sha256-7BJzzdDOKbqzavo5S6kzngSP31tlqutfIcDNvIzj8hM="
         },
-        "checksum": "Q1NkEgltHxH7K57K6lLQvJS3MrBaQ="
+        "checksum": "Q15xWfLjHv2pnAj/oWRzXeczLiN5E="
       },
       {
         "name": "openssh-server",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssh-server-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssh-server-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4833",
-          "checksum": "sha1-kUiOxMgAGrJ5fjkvFbEDDVGGPis="
+          "range": "bytes=0-4934",
+          "checksum": "sha1-P63udW0uiV+E0gY0gYbTeH9YrxU="
         },
         "data": {
-          "range": "bytes=4834-1265747",
-          "checksum": "sha256-AXMBx4NhrX+uE/z9m66e1WdeNeuSGUhWwNk9Qjo8xlg="
+          "range": "bytes=4935-1252220",
+          "checksum": "sha256-RsxvP9PdoxT5AJMCCZxv5Af/8XrIeb/iLzeFyha4ImA="
         },
-        "checksum": "Q1kUiOxMgAGrJ5fjkvFbEDDVGGPis="
+        "checksum": "Q1P63udW0uiV+E0gY0gYbTeH9YrxU="
       },
       {
         "name": "openssh-sftp-server",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssh-sftp-server-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssh-sftp-server-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4752",
-          "checksum": "sha1-6smsAIjvZEW34LjnO9ZnR10Thow="
+          "range": "bytes=0-4848",
+          "checksum": "sha1-caAUIujVomqQ9ubLYAmsak9qcB8="
         },
         "data": {
-          "range": "bytes=4753-89779",
-          "checksum": "sha256-tjgUOEzdm9nfdpw02Dc/QW6F8sNYeCAXLhlv79de0r4="
+          "range": "bytes=4849-89106",
+          "checksum": "sha256-cxGno7PwD9bfo+4iS4hvZ9A62IBC0EbuEciCguyksYA="
         },
-        "checksum": "Q16smsAIjvZEW34LjnO9ZnR10Thow="
+        "checksum": "Q1caAUIujVomqQ9ubLYAmsak9qcB8="
       },
       {
         "name": "openssh",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssh-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssh-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4733",
-          "checksum": "sha1-qwf5QMVgdvixAFZKMSBdzr07jwg="
+          "range": "bytes=0-4832",
+          "checksum": "sha1-MB1Ubjs2QGyD8tUiO7JNH/Ph5Ig="
         },
         "data": {
-          "range": "bytes=4734-5993",
-          "checksum": "sha256-tavVnla8PsAy8/MQsslbx0nOv2Qe47lQl2a1HRMJyLM="
+          "range": "bytes=4833-6206",
+          "checksum": "sha256-NAtSxrjP/ZHlVQT1c0dKh070uXwLLl0EZeQggO5l1Ik="
         },
-        "checksum": "Q1qwf5QMVgdvixAFZKMSBdzr07jwg="
+        "checksum": "Q1MB1Ubjs2QGyD8tUiO7JNH/Ph5Ig="
       },
       {
         "name": "openssl",
-        "url": "https://packages.wolfi.dev/os/aarch64/openssl-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssl-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8982",
-          "checksum": "sha1-xFV8mHqPLzHfx0ZMtQFqAz/+HR8="
+          "range": "bytes=0-9110",
+          "checksum": "sha1-RwOKvGwRP4Rl1D2ba5gS2eVCuIk="
         },
         "data": {
-          "range": "bytes=8983-429901",
-          "checksum": "sha256-fwbU6RfordZwpUQya9tPW6nQYSIZjmSyulqXmnripII="
+          "range": "bytes=9111-429164",
+          "checksum": "sha256-C0LvOhfHDROeG6K4kutFrZiF9hK5T2QtlLELJhZf3pw="
         },
-        "checksum": "Q1xFV8mHqPLzHfx0ZMtQFqAz/+HR8="
+        "checksum": "Q1RwOKvGwRP4Rl1D2ba5gS2eVCuIk="
       },
       {
         "name": "unzip",
-        "url": "https://packages.wolfi.dev/os/aarch64/unzip-6.0-r1.apk",
-        "version": "6.0-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/unzip-6.0-r3.apk",
+        "version": "6.0-r3",
         "architecture": "aarch64",
         "signature": {
-          "range": "bytes=0-707",
-          "checksum": "sha1-FVFCZPGkvLN4LcUQwmKWdT7i5T4="
+          "range": "",
+          "checksum": ""
         },
         "control": {
-          "range": "bytes=708-1114",
-          "checksum": "sha1-+3UQLM4JRJoHVBWjwPmPIfED+Gc="
+          "range": "bytes=0-3053",
+          "checksum": "sha1-h6rXxhT9qMdL0PpErjlbWZ/iP+4="
         },
         "data": {
-          "range": "bytes=1115-131506",
-          "checksum": "sha256-LhqntOWRKzAa6bZ4sBcsuVW87ugPjrdC0S6VOjckv3M="
+          "range": "bytes=3054-204772",
+          "checksum": "sha256-g4ywoJpLgl+J2vF9PHQ48RhXG3OELmK/lQdzgxML5Wc="
         },
-        "checksum": "Q1+3UQLM4JRJoHVBWjwPmPIfED+Gc="
+        "checksum": "Q1h6rXxhT9qMdL0PpErjlbWZ/iP+4="
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r20.apk",
-        "version": "20230201-r20",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r23.apk",
+        "version": "20230201-r23",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1628",
-          "checksum": "sha1-13r0mEPRLFoMGaeH7lUbK+eLOto="
+          "range": "bytes=0-1743",
+          "checksum": "sha1-5GKR2cusJFuJW5jYQBxRRQK9xTs="
         },
         "data": {
-          "range": "bytes=1629-13059",
-          "checksum": "sha256-AsquTxi+xNTtxQ+7s3wbWRgvCqzpOg2+uQ+rQGcXG7E="
+          "range": "bytes=1744-13281",
+          "checksum": "sha256-dR349XhAoTV5W5l/P5+zNKf3KdcfnchfEGPQTZh9Eb0="
         },
-        "checksum": "Q113r0mEPRLFoMGaeH7lUbK+eLOto="
+        "checksum": "Q15GKR2cusJFuJW5jYQBxRRQK9xTs="
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20241121-r40.apk",
-        "version": "20241121-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20250619-r5.apk",
+        "version": "20250619-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5278",
-          "checksum": "sha1-SXMRsIH38wqnaJ3OwcMcIbMB5lE="
+          "range": "bytes=0-6015",
+          "checksum": "sha1-tfDipbGD4FekKD/gOgiW/BJVZW0="
         },
         "data": {
-          "range": "bytes=5279-136746",
-          "checksum": "sha256-kdckTWjTwjBnWrkz0ALdoGWjA5VbTvnmok48RnFyrlE="
+          "range": "bytes=6016-131890",
+          "checksum": "sha256-QNAhanIIS8Fii0azPAlI/ZO+St5S87HQOJa8C1W3ir4="
         },
-        "checksum": "Q1SXMRsIH38wqnaJ3OwcMcIbMB5lE="
+        "checksum": "Q1tfDipbGD4FekKD/gOgiW/BJVZW0="
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17772",
-          "checksum": "sha1-z6/r5u04ry70FCKAf1bna7uP2hU="
+          "range": "bytes=0-12977",
+          "checksum": "sha1-Q7n3NwDvuB/5QAlLSUvDcg9IbKE="
         },
         "data": {
-          "range": "bytes=17773-704762",
-          "checksum": "sha256-XcBDCrpfoSjyHMJ4mWeUPb/ACQXes7E3rlL3MGehCHk="
+          "range": "bytes=12978-142179",
+          "checksum": "sha256-MatFN+S2wR1mXGo4xi4dwBJpQw3uXVdtiOBtz7p1DiI="
         },
-        "checksum": "Q1z6/r5u04ry70FCKAf1bna7uP2hU="
+        "checksum": "Q1Q7n3NwDvuB/5QAlLSUvDcg9IbKE="
       },
       {
         "name": "libgcc",
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-14.2.0-r12.apk",
-        "version": "14.2.0-r12",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-15.2.0-r0.apk",
+        "version": "15.2.0-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5832",
-          "checksum": "sha1-FcC3c+uEDjXLs3SPvcflXelPGL8="
+          "range": "bytes=0-6085",
+          "checksum": "sha1-yC91cq07MtdPoSnZ/e4j47KwlLU="
         },
         "data": {
-          "range": "bytes=5833-100428",
-          "checksum": "sha256-zHGFPpQLdFIcW/xXFPusvmv2PzB+kNK2ur0F0NWHAWA="
+          "range": "bytes=6086-100221",
+          "checksum": "sha256-T9demvxVXpVu792wPzUqibp6aQvqtoQyYKreV6vnnOI="
         },
-        "checksum": "Q1FcC3c+uEDjXLs3SPvcflXelPGL8="
+        "checksum": "Q1yC91cq07MtdPoSnZ/e4j47KwlLU="
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17746",
-          "checksum": "sha1-lXXHntQ/7cTgQnU8gl59jCScE1c="
+          "range": "bytes=0-12914",
+          "checksum": "sha1-jysComX6GNf7ds/8F/vdHeUTc3k="
         },
         "data": {
-          "range": "bytes=17747-93741",
-          "checksum": "sha256-SA47aNAR7uNahlOz5co077i9FBuZcN3f7uSZ4Z2btkY="
+          "range": "bytes=12915-89042",
+          "checksum": "sha256-LGkJ4JQCpggNQNJbepMow5whAc0CyNPbe82R1OgcClk="
         },
-        "checksum": "Q1lXXHntQ/7cTgQnU8gl59jCScE1c="
+        "checksum": "Q1jysComX6GNf7ds/8F/vdHeUTc3k="
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17906",
-          "checksum": "sha1-g2VxUkpuEvo68AKiW6PEC5VuziA="
+          "range": "bytes=0-13173",
+          "checksum": "sha1-n1ty/Fb9oVbFF0nkZp8Av72PLTQ="
         },
         "data": {
-          "range": "bytes=17907-9778110",
-          "checksum": "sha256-izYDuNjcCmipHK630vMoxNRF9OoBWAFLBt7bGpbybLY="
+          "range": "bytes=13174-2893419",
+          "checksum": "sha256-HUtm178rjNrcoXEfGzmxvmJpqhW4GPjlElHBChBk1bY="
         },
-        "checksum": "Q1g2VxUkpuEvo68AKiW6PEC5VuziA="
+        "checksum": "Q1n1ty/Fb9oVbFF0nkZp8Av72PLTQ="
       },
       {
         "name": "libxcrypt",
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.38-r1.apk",
-        "version": "4.4.38-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.38-r4.apk",
+        "version": "4.4.38-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7034",
-          "checksum": "sha1-ZHBMgu6bunisUBcF0R3YEQZc7Hw="
+          "range": "bytes=0-6666",
+          "checksum": "sha1-ARKVRod69JglgHYfA7Jjs1yigts="
         },
         "data": {
-          "range": "bytes=7035-92050",
-          "checksum": "sha256-eKW+wshn3K1zp4ZXVVwW0ntXeH24dQs1kuKq4i/iF5E="
+          "range": "bytes=6667-92460",
+          "checksum": "sha256-jTHfNR1n0LPpgRNPfcjXoM2v1ur/DWbodQHZHpmRF3s="
         },
-        "checksum": "Q1ZHBMgu6bunisUBcF0R3YEQZc7Hw="
+        "checksum": "Q1ARKVRod69JglgHYfA7Jjs1yigts="
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17808",
-          "checksum": "sha1-Ts4nEDCH/Jx2sAd77zFVOQKQn84="
+          "range": "bytes=0-12966",
+          "checksum": "sha1-oX0abHV9oimmFr7yir0v3+yeszY="
         },
         "data": {
-          "range": "bytes=17809-18951",
-          "checksum": "sha256-kLHdS1yw5LrHLVp8o+fN7jmj8KPz9sYZD40ZS26hh34="
+          "range": "bytes=12967-14248",
+          "checksum": "sha256-B0pkEypiYdEuLqSlbgk6LaCd5X4LwOTLfXItZ7N7PD4="
         },
-        "checksum": "Q1Ts4nEDCH/Jx2sAd77zFVOQKQn84="
+        "checksum": "Q1oX0abHV9oimmFr7yir0v3+yeszY="
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r40.apk",
-        "version": "1.37.0-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r48.apk",
+        "version": "1.37.0-r48",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6256",
-          "checksum": "sha1-LInTlXp+HUmKix0sbwTHmV440Qc="
+          "range": "bytes=0-6365",
+          "checksum": "sha1-25Lnt5/Z++DnCtkcDTl9k2YMg5I="
         },
         "data": {
-          "range": "bytes=6257-422224",
-          "checksum": "sha256-3r9aMobGULBrS0sQCI604/ZvzpzMmXBzr06esybQWlU="
+          "range": "bytes=6366-422440",
+          "checksum": "sha256-dSxSIv2DXO2mQ6isMDg860IVUU4BeVytENJWUV/W/bI="
         },
-        "checksum": "Q1LInTlXp+HUmKix0sbwTHmV440Qc="
+        "checksum": "Q125Lnt5/Z++DnCtkcDTl9k2YMg5I="
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8927",
-          "checksum": "sha1-gmC+Eb40K8Hsw3giUEyq1L4p3gc="
+          "range": "bytes=0-9065",
+          "checksum": "sha1-kFScXMyqaOaaYNq1OBKYyP0znY0="
         },
         "data": {
-          "range": "bytes=8928-2295853",
-          "checksum": "sha256-ZNw3IVWoD9Mej/7+WBpRtC0csC/OgypQ5sxAOtI9tC8="
+          "range": "bytes=9066-2309962",
+          "checksum": "sha256-3wXCRnY+O3Q8cVEQqihb7wn9NaJ30mImMvyKQly3xrQ="
         },
-        "checksum": "Q1gmC+Eb40K8Hsw3giUEyq1L4p3gc="
+        "checksum": "Q1kFScXMyqaOaaYNq1OBKYyP0znY0="
       },
       {
         "name": "ca-certificates",
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20241121-r40.apk",
-        "version": "20241121-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20250619-r5.apk",
+        "version": "20250619-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5335",
-          "checksum": "sha1-5Hj4G2RnmBUz6Gjn/7ZqrYOpud8="
+          "range": "bytes=0-6077",
+          "checksum": "sha1-oQWS/ndbPYykqNgTYjc0wn7aZcs="
         },
         "data": {
-          "range": "bytes=5336-168172",
-          "checksum": "sha256-cotk3H3J2gxvmdShsYKdUgJZrIpvti9okxlPNk5cNHI="
+          "range": "bytes=6078-162515",
+          "checksum": "sha256-0Vgni4TQ7YDWl6N22HauDk46GFn85OC/6E0hfAxk0kc="
         },
-        "checksum": "Q15Hj4G2RnmBUz6Gjn/7ZqrYOpud8="
+        "checksum": "Q1oQWS/ndbPYykqNgTYjc0wn7aZcs="
       },
       {
         "name": "chainctl",
-        "url": "https://packages.cgr.dev/extras/x86_64/chainctl-0.2.76-r0.apk",
-        "version": "0.2.76-r0",
+        "url": "https://packages.cgr.dev/extras/x86_64/chainctl-0.2.121-r0.apk",
+        "version": "0.2.121-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1664",
-          "checksum": "sha1-7LuUu+Iuos5PoAfH8rASAkqbt3A="
+          "range": "bytes=0-1674",
+          "checksum": "sha1-/m8/4dHj6EhTMCY64/HjMEAgbBU="
         },
         "data": {
-          "range": "bytes=1665-24458382",
-          "checksum": "sha256-SeqAjLDZff42PoULDpn9Ubnwvxg/0RVcPgAXJFLCHzA="
+          "range": "bytes=1675-31419143",
+          "checksum": "sha256-CeCN6cl8Ah9Xkc4pKoJ27S3UaEBhLrs1658hzOp/I6E="
         },
-        "checksum": "Q17LuUu+Iuos5PoAfH8rASAkqbt3A="
+        "checksum": "Q1/m8/4dHj6EhTMCY64/HjMEAgbBU="
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r6.apk",
-        "version": "1.3.1-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r51.apk",
+        "version": "1.3.1-r51",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8151",
-          "checksum": "sha1-WC5ueST8mSvu2Vq5aGscl+br858="
+          "range": "bytes=0-7282",
+          "checksum": "sha1-/kfcansNYm3y06m+tgXyDJMjPqs="
         },
         "data": {
-          "range": "bytes=8152-67192",
-          "checksum": "sha256-Y04E/I4Echr0bvvjPfuLqalfCFkYKUiZhOgKrfTDqo0="
+          "range": "bytes=7283-67255",
+          "checksum": "sha256-gthB7I68g/ezQRlM7Z3bkM8KhxgqwSHxu4RqF5xscKE="
         },
-        "checksum": "Q1WC5ueST8mSvu2Vq5aGscl+br858="
+        "checksum": "Q1/kfcansNYm3y06m+tgXyDJMjPqs="
       },
       {
         "name": "libunistring",
-        "url": "https://packages.wolfi.dev/os/x86_64/libunistring-1.3-r1.apk",
-        "version": "1.3-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libunistring-1.3-r4.apk",
+        "version": "1.3-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-392",
-          "checksum": "sha1-YwS3Xn/DGzsKKuLsmPHiRIgM9Js="
+          "range": "bytes=0-3797",
+          "checksum": "sha1-FkwqQFRVjXDEH/BxWwim7TIxeAc="
         },
         "data": {
-          "range": "bytes=393-960671",
-          "checksum": "sha256-H6mMaiw9S3Odrx6g/sVNNOjlCL8ygl1v9Ma3FSWsryo="
+          "range": "bytes=3798-966179",
+          "checksum": "sha256-1ukEzam8XYZrtj+WnZIV1gZ5GqKPNfDfcNnXa7VnYgA="
         },
-        "checksum": "Q1YwS3Xn/DGzsKKuLsmPHiRIgM9Js="
+        "checksum": "Q1FkwqQFRVjXDEH/BxWwim7TIxeAc="
       },
       {
         "name": "libidn2",
-        "url": "https://packages.wolfi.dev/os/x86_64/libidn2-2.3.8-r0.apk",
-        "version": "2.3.8-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libidn2-2.3.8-r3.apk",
+        "version": "2.3.8-r3",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5146",
-          "checksum": "sha1-XWJsaqhROBYpKx6hHNkwtqvsuZ0="
+          "range": "bytes=0-4151",
+          "checksum": "sha1-D5VW3U5TV6bRQxnIMkDL+k1DYxc="
         },
         "data": {
-          "range": "bytes=5147-131392",
-          "checksum": "sha256-NJ/DJ8GS5Uhm1Bn4sqOABBrLchqtE5ZM5M+2z5Zo2Qo="
+          "range": "bytes=4152-130330",
+          "checksum": "sha256-z3cDVkennHOdpKRPJqNIVfL8HSYSGCHLnInrBHcR/xM="
         },
-        "checksum": "Q1XWJsaqhROBYpKx6hHNkwtqvsuZ0="
+        "checksum": "Q1D5VW3U5TV6bRQxnIMkDL+k1DYxc="
       },
       {
         "name": "libpsl",
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r4.apk",
-        "version": "0.21.5-r4",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r6.apk",
+        "version": "0.21.5-r6",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-381",
-          "checksum": "sha1-wacyzaZNKxvcE2wVQ3dAaKOLXIc="
+          "range": "bytes=0-6102",
+          "checksum": "sha1-/80XLoSwVVr1oCbINCxsdRjSRLQ="
         },
         "data": {
-          "range": "bytes=382-60969",
-          "checksum": "sha256-G37Uk59FzdyQ3etqsgBUsEzFuWoEqzFpHq19fuw61LU="
+          "range": "bytes=6103-67028",
+          "checksum": "sha256-hMjN6gHPuMqDUfNFL9uTy3v8fimQtNWffHNRgh6ZIk4="
         },
-        "checksum": "Q1wacyzaZNKxvcE2wVQ3dAaKOLXIc="
+        "checksum": "Q1/80XLoSwVVr1oCbINCxsdRjSRLQ="
       },
       {
         "name": "libbrotlicommon1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r4.apk",
-        "version": "1.1.0-r4",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r7.apk",
+        "version": "1.1.0-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-699",
-          "checksum": "sha1-FuwhZ4A06S7E3+M3fpy9tu6oWEc="
+          "range": "",
+          "checksum": ""
         },
         "control": {
-          "range": "bytes=700-1044",
-          "checksum": "sha1-DoOZOSza7UNgzRKEjQP4JaLDDx0="
+          "range": "bytes=0-5636",
+          "checksum": "sha1-TQMxy9eRiGa56rYE/ufilWFSE4g="
         },
         "data": {
-          "range": "bytes=1045-70102",
-          "checksum": "sha256-O17OIPyJKgsX2KjWWPz2xcy9i+hLVEi1fMlTIxN6U/c="
+          "range": "bytes=5637-75518",
+          "checksum": "sha256-dW0ANdGyIec024M27MaSnBjrbQyKo/oBhftozykxD6E="
         },
-        "checksum": "Q1DoOZOSza7UNgzRKEjQP4JaLDDx0="
+        "checksum": "Q1TQMxy9eRiGa56rYE/ufilWFSE4g="
       },
       {
         "name": "libbrotlidec1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r4.apk",
-        "version": "1.1.0-r4",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r7.apk",
+        "version": "1.1.0-r7",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-695",
-          "checksum": "sha1-UglMDNBf9ULB9iblLZZtlPZH16Y="
+          "range": "",
+          "checksum": ""
         },
         "control": {
-          "range": "bytes=696-1045",
-          "checksum": "sha1-VP1j2xFswKYXqv/BvCJz40CZ1ik="
+          "range": "bytes=0-5647",
+          "checksum": "sha1-Fz3/w5yb+CehPBRsCkivP52VMh8="
         },
         "data": {
-          "range": "bytes=1046-25345",
-          "checksum": "sha256-bk1ZGN4d1FL0esXzoXma9dYOU2DKRx6sJYqQ9X+Uspc="
+          "range": "bytes=5648-35716",
+          "checksum": "sha256-aQ/w9C+fAhXxr+b8V7Df3TO0+LPUUJ7wcDM9tTQt1y8="
         },
-        "checksum": "Q1VP1j2xFswKYXqv/BvCJz40CZ1ik="
+        "checksum": "Q1Fz3/w5yb+CehPBRsCkivP52VMh8="
       },
       {
         "name": "libverto",
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
-        "version": "0.3.2-r4",
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r6.apk",
+        "version": "0.3.2-r6",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-692",
-          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ="
+          "range": "",
+          "checksum": ""
         },
         "control": {
-          "range": "bytes=693-1048",
-          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw="
+          "range": "bytes=0-5926",
+          "checksum": "sha1-gnPEX/D3QZLHFoD3MdL0XzWk11Q="
         },
         "data": {
-          "range": "bytes=1049-13100",
-          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc="
+          "range": "bytes=5927-18863",
+          "checksum": "sha256-7G7tkgmU/XoawtlJNCR49y6bITsfAzQ0AVg8fHn8F6Y="
         },
-        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw="
+        "checksum": "Q1gnPEX/D3QZLHFoD3MdL0XzWk11Q="
       },
       {
         "name": "krb5-conf",
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-conf-1.0-r5.apk",
-        "version": "1.0-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-conf-1.0-r7.apk",
+        "version": "1.0-r7",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1007",
-          "checksum": "sha1-/zS/GBo0x36iSTF2Gi1ZfRbuF0k="
+          "range": "bytes=0-1022",
+          "checksum": "sha1-pj7BsZ/LkrnigRcGPD/0wDf5gR4="
         },
         "data": {
-          "range": "bytes=1008-2315",
-          "checksum": "sha256-VMNKKquR3oC/mJNJK3Vi/+JTkf7ZGM6IfrXRmlDH7B8="
+          "range": "bytes=1023-2390",
+          "checksum": "sha256-wff2/goh7ZWi26KKcViVaoAknSVnVL9yMIVOwF2kgC4="
         },
-        "checksum": "Q1/zS/GBo0x36iSTF2Gi1ZfRbuF0k="
+        "checksum": "Q1pj7BsZ/LkrnigRcGPD/0wDf5gR4="
       },
       {
         "name": "libcom_err",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcom_err-1.47.2-r21.apk",
-        "version": "1.47.2-r21",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcom_err-1.47.3-r1.apk",
+        "version": "1.47.3-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7676",
-          "checksum": "sha1-XN3EG4CHtwrLkmdJ8uHuL6nNb2A="
+          "range": "bytes=0-7314",
+          "checksum": "sha1-opQteMgICxS71la87LmqhTq9iG8="
         },
         "data": {
-          "range": "bytes=7677-15563",
-          "checksum": "sha256-6UnzwDt8vAiphNzipc3BQbap/NAgu7fZNhtEB9TwI3M="
+          "range": "bytes=7315-15479",
+          "checksum": "sha256-n3hXoCr5d/sq1xLXbTIH+kH3UuHvUZ3MYRKCfatC7ag="
         },
-        "checksum": "Q1XN3EG4CHtwrLkmdJ8uHuL6nNb2A="
+        "checksum": "Q1opQteMgICxS71la87LmqhTq9iG8="
       },
       {
         "name": "keyutils-libs",
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r31.apk",
-        "version": "1.6.3-r31",
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r37.apk",
+        "version": "1.6.3-r37",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6961",
-          "checksum": "sha1-HTuX7jd6bSDzlOGnGYaTlmC2FG4="
+          "range": "bytes=0-6591",
+          "checksum": "sha1-D1A0HhjpR1TLHd2OOPaPEOmdBEY="
         },
         "data": {
-          "range": "bytes=6962-16813",
-          "checksum": "sha256-XTnDY7ZhV5v+OQeT2z/Nsd/zmlQdOIMXgWwTesohTIM="
+          "range": "bytes=6592-16741",
+          "checksum": "sha256-dKfQFmMsl75C38/9aCBwMnDx4/wHGAW2KI2MUnAhYpc="
         },
-        "checksum": "Q1HTuX7jd6bSDzlOGnGYaTlmC2FG4="
+        "checksum": "Q1D1A0HhjpR1TLHd2OOPaPEOmdBEY="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8930",
-          "checksum": "sha1-Dlhg7IYpt5wllRSv1cA7zlnhpyA="
+          "range": "bytes=0-9073",
+          "checksum": "sha1-3KUYsFYdhVMxnC16CoycflTDIVo="
         },
         "data": {
-          "range": "bytes=8931-487922",
-          "checksum": "sha256-QZH47VGlQVtd7SGLiS8wXNTexl39RDAo7VYwU0ttw7w="
+          "range": "bytes=9074-494008",
+          "checksum": "sha256-cUBmJ+dt7HeAsHFlR79EYt9GflWS95k3OTP78FdD03Q="
         },
-        "checksum": "Q1Dlhg7IYpt5wllRSv1cA7zlnhpyA="
+        "checksum": "Q13KUYsFYdhVMxnC16CoycflTDIVo="
       },
       {
         "name": "krb5-libs",
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r40.apk",
-        "version": "1.21.3-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.22-r2.apk",
+        "version": "1.22-r2",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6894",
-          "checksum": "sha1-SbaeUhWmJeJ+GtZ1jkO3R5+JL5g="
+          "range": "bytes=0-7829",
+          "checksum": "sha1-blQVdao1GgyTgLs6+66UAQhUaPE="
         },
         "data": {
-          "range": "bytes=6895-1025040",
-          "checksum": "sha256-YhlGPj6JmIpK470mpaBKjEXYjz8OAfbe9wfh25oS8pc="
+          "range": "bytes=7830-1044764",
+          "checksum": "sha256-/XH54UjzaGZud/j2ys6cdLf4On7rBI3bFl/00fNfpvg="
         },
-        "checksum": "Q1SbaeUhWmJeJ+GtZ1jkO3R5+JL5g="
+        "checksum": "Q1blQVdao1GgyTgLs6+66UAQhUaPE="
       },
       {
         "name": "ncurses-terminfo-base",
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20241228-r1.apk",
-        "version": "6.5_p20241228-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20250621-r1.apk",
+        "version": "6.5_p20250621-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5977",
-          "checksum": "sha1-l/ZxGYeyXeU7opCsRwMHYHp0nGc="
+          "range": "bytes=0-4603",
+          "checksum": "sha1-0gu1QUVgdXfikW39OIPVRtKV4j0="
         },
         "data": {
-          "range": "bytes=5978-104019",
-          "checksum": "sha256-wdVcdMVcoWqtclqWU361DV1yYVc62kCTwfwlrA5C9jI="
+          "range": "bytes=4604-106057",
+          "checksum": "sha256-dU2kl5T+hqzKHFTLsRgjcDwE9jjpog670+vMBmwR6LQ="
         },
-        "checksum": "Q1l/ZxGYeyXeU7opCsRwMHYHp0nGc="
+        "checksum": "Q10gu1QUVgdXfikW39OIPVRtKV4j0="
       },
       {
         "name": "ncurses",
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20241228-r1.apk",
-        "version": "6.5_p20241228-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20250621-r1.apk",
+        "version": "6.5_p20250621-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6071",
-          "checksum": "sha1-DbmnYdq3IkcuCokcTefI3bIEBqo="
+          "range": "bytes=0-4724",
+          "checksum": "sha1-kbFG5Kjwqq4WUiKYGhUAewvjWGQ="
         },
         "data": {
-          "range": "bytes=6072-441739",
-          "checksum": "sha256-e//ncRikGxgjzhozBGDjIuJ6lshB5eWO73kJ50xhyts="
+          "range": "bytes=4725-447404",
+          "checksum": "sha256-dZfJ+jHW7gn9zAFoWnKGp7iHgWBvHv6ql5NtcDivn7k="
         },
-        "checksum": "Q1DbmnYdq3IkcuCokcTefI3bIEBqo="
+        "checksum": "Q1kbFG5Kjwqq4WUiKYGhUAewvjWGQ="
       },
       {
         "name": "readline",
-        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2.13-r3.apk",
-        "version": "8.2.13-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.3-r1.apk",
+        "version": "8.3-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-3992",
-          "checksum": "sha1-0GJyB1F3Y5AOY2dVlA59Y2YVpxI="
+          "range": "bytes=0-3887",
+          "checksum": "sha1-vL4XjVse3ZTOexy4Rl4c2olko9s="
         },
         "data": {
-          "range": "bytes=3993-320549",
-          "checksum": "sha256-nEOMCMKpBwVIDfQ0rIlddqr7w8V9xOlQ+AwZeTQm7sU="
+          "range": "bytes=3888-339634",
+          "checksum": "sha256-MO7S4LbvC4dyv4Lzk8eq1BPdU/CveFeJVR11vqHZQ+Q="
         },
-        "checksum": "Q10GJyB1F3Y5AOY2dVlA59Y2YVpxI="
+        "checksum": "Q1vL4XjVse3ZTOexy4Rl4c2olko9s="
       },
       {
         "name": "sqlite-libs",
-        "url": "https://packages.wolfi.dev/os/x86_64/sqlite-libs-3.49.2-r0.apk",
-        "version": "3.49.2-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/sqlite-libs-3.50.4-r0.apk",
+        "version": "3.50.4-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4304",
-          "checksum": "sha1-fLIiEdmSKW31lH19F7v9qYOu/sc="
+          "range": "bytes=0-4389",
+          "checksum": "sha1-SHgfKntZVPKbRKAl29AYCqzA9h4="
         },
         "data": {
-          "range": "bytes=4305-870931",
-          "checksum": "sha256-ra25KvifN/UYJdQfZ94Shyf4caxPAY4Akq5Izv5TZYg="
+          "range": "bytes=4390-879157",
+          "checksum": "sha256-p0j/Jet1dWjQN1HiCLZMlGTbaAj5YmaENvJqvKQphJ8="
         },
-        "checksum": "Q1fLIiEdmSKW31lH19F7v9qYOu/sc="
+        "checksum": "Q1SHgfKntZVPKbRKAl29AYCqzA9h4="
       },
       {
         "name": "heimdal-libs",
-        "url": "https://packages.wolfi.dev/os/x86_64/heimdal-libs-7.8.0-r40.apk",
-        "version": "7.8.0-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/heimdal-libs-7.8.0-r42.apk",
+        "version": "7.8.0-r42",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4915",
-          "checksum": "sha1-1ngZYq9kGsYWj2X95RkCFXpiFZ4="
+          "range": "bytes=0-5130",
+          "checksum": "sha1-pfW0SfzaMSuCBXynTvWVgxsJ+eo="
         },
         "data": {
-          "range": "bytes=4916-1419472",
-          "checksum": "sha256-9nRx51Ao6llDsn2OKln8em2KJHq8Al+n92Hebv8TEKI="
+          "range": "bytes=5131-1422790",
+          "checksum": "sha256-kl5/nkYhSc6v+WPFgmIsSnN9yGNXNgvlXiO75AWegHs="
         },
-        "checksum": "Q11ngZYq9kGsYWj2X95RkCFXpiFZ4="
+        "checksum": "Q1pfW0SfzaMSuCBXynTvWVgxsJ+eo="
       },
       {
         "name": "gdbm",
-        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.25-r0.apk",
-        "version": "1.25-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.26-r1.apk",
+        "version": "1.26-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-3495",
-          "checksum": "sha1-D7i5yW117K2LcIIpdtxZwvOCQyw="
+          "range": "bytes=0-4301",
+          "checksum": "sha1-IBbN0u+wDuGiKJW7ExWlnCDdiOc="
         },
         "data": {
-          "range": "bytes=3496-253631",
-          "checksum": "sha256-9v103tXW4ZqGX1XMnA3vQtGyxZR5i3E3iQWFNmq+HLA="
+          "range": "bytes=4302-256269",
+          "checksum": "sha256-ARxaWvviIVwBvxn2jaPNcF4x7TFniCwhXZRc3VVshE8="
         },
-        "checksum": "Q1D7i5yW117K2LcIIpdtxZwvOCQyw="
+        "checksum": "Q1IBbN0u+wDuGiKJW7ExWlnCDdiOc="
       },
       {
         "name": "cyrus-sasl",
-        "url": "https://packages.wolfi.dev/os/x86_64/cyrus-sasl-2.1.28-r40.apk",
-        "version": "2.1.28-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/cyrus-sasl-2.1.28-r44.apk",
+        "version": "2.1.28-r44",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6391",
-          "checksum": "sha1-Gfa8fehbC/uTA333Q65f59k3h/o="
+          "range": "bytes=0-7313",
+          "checksum": "sha1-morHkG6muWIhgyIispZQj5R7lYg="
         },
         "data": {
-          "range": "bytes=6392-302663",
-          "checksum": "sha256-bWJHVP0XPhKeGa7jRx2KdPkCMfCp10Wp8iK+OI7IHbU="
+          "range": "bytes=7314-275537",
+          "checksum": "sha256-ubgZOm49SfEUrgmE4rhibu3cNlF+qTDMoCCUQ6SoxVY="
         },
-        "checksum": "Q1Gfa8fehbC/uTA333Q65f59k3h/o="
+        "checksum": "Q1morHkG6muWIhgyIispZQj5R7lYg="
       },
       {
         "name": "libldap",
-        "url": "https://packages.wolfi.dev/os/x86_64/libldap-2.6.9-r41.apk",
-        "version": "2.6.9-r41",
+        "url": "https://packages.wolfi.dev/os/x86_64/libldap-2.6.10-r5.apk",
+        "version": "2.6.10-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-9518",
-          "checksum": "sha1-C2qenqk07gnIYQGce+ldvhnc8Rw="
+          "range": "bytes=0-9642",
+          "checksum": "sha1-eKBFOIiOFp/taYhzAKnRW9DPYcg="
         },
         "data": {
-          "range": "bytes=9519-245726",
-          "checksum": "sha256-6FcUKdITglR7IxnKcie9qvOWs04YQ8YtJebsgpkz3u0="
+          "range": "bytes=9643-250508",
+          "checksum": "sha256-DkmAUSa5Nr1UiiPMM384XuL7IKiZ+/M0fv8EWVSmg+I="
         },
-        "checksum": "Q1C2qenqk07gnIYQGce+ldvhnc8Rw="
+        "checksum": "Q1eKBFOIiOFp/taYhzAKnRW9DPYcg="
       },
       {
         "name": "libnghttp2-14",
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.65.0-r0.apk",
-        "version": "1.65.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.66.0-r1.apk",
+        "version": "1.66.0-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7046",
-          "checksum": "sha1-XLwGABB9Q5GwSLUWLldeCbPhCOE="
+          "range": "bytes=0-6080",
+          "checksum": "sha1-0IqaBH+eUDx6Pfox3VeSv/YHk5Y="
         },
         "data": {
-          "range": "bytes=7047-102701",
-          "checksum": "sha256-SFB9g3NfTdrDQdS8Liu0cvMm0WqKUMVymsomb2O4CHw="
+          "range": "bytes=6081-103812",
+          "checksum": "sha256-p7iwPTEHKS/K21Dl7w7XcEPEF28jDc0npIFwEI+NGF4="
         },
-        "checksum": "Q1XLwGABB9Q5GwSLUWLldeCbPhCOE="
+        "checksum": "Q10IqaBH+eUDx6Pfox3VeSv/YHk5Y="
       },
       {
         "name": "libcurl-openssl4",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.13.0-r0.apk",
-        "version": "8.13.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.15.0-r4.apk",
+        "version": "8.15.0-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4913",
-          "checksum": "sha1-p392qBhnoB/HJp8zH7SAGqIaOB4="
+          "range": "bytes=0-7374",
+          "checksum": "sha1-xD/kI4DVR2xWsac+dqgYZcNUIi4="
         },
         "data": {
-          "range": "bytes=4914-454880",
-          "checksum": "sha256-E9/Xfaltgt2ESsJ81994uBdSD8TJR5FzY3+xw0HX+u4="
+          "range": "bytes=7375-478333",
+          "checksum": "sha256-Ccxh14StTZG7rmKmoIvYkj4B5sa8TxqhahviCQ7t1/o="
         },
-        "checksum": "Q1p392qBhnoB/HJp8zH7SAGqIaOB4="
+        "checksum": "Q1xD/kI4DVR2xWsac+dqgYZcNUIi4="
       },
       {
         "name": "curl",
@@ -1713,60 +1713,60 @@
       },
       {
         "name": "libpcre2-8-0",
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.45-r1.apk",
-        "version": "10.45-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.45-r3.apk",
+        "version": "10.45-r3",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7917",
-          "checksum": "sha1-62i5nL0jxgc5LtWHz/0TAt9JBwQ="
+          "range": "bytes=0-6710",
+          "checksum": "sha1-OPxr5L9gHq95asXM05dwNwMX0hA="
         },
         "data": {
-          "range": "bytes=7918-303352",
-          "checksum": "sha256-STkRndqvp0/xGFP8f4Boosg4W0TlKbuGXholK5oh4Qs="
+          "range": "bytes=6711-302979",
+          "checksum": "sha256-kWZKJf6jvxfFg/R/DlaYJDBZ4Hr9VViOmfACqfY/oEc="
         },
-        "checksum": "Q162i5nL0jxgc5LtWHz/0TAt9JBwQ="
+        "checksum": "Q1OPxr5L9gHq95asXM05dwNwMX0hA="
       },
       {
         "name": "libexpat1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libexpat1-2.7.1-r0.apk",
-        "version": "2.7.1-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libexpat1-2.7.1-r3.apk",
+        "version": "2.7.1-r3",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4183",
-          "checksum": "sha1-eY5w1Fo9xL3drNiqZKlle/V4F0Y="
+          "range": "bytes=0-4974",
+          "checksum": "sha1-MPXmrT/Y0Us4tb3Sunsj3I4O/fs="
         },
         "data": {
-          "range": "bytes=4184-84705",
-          "checksum": "sha256-4dr8xpP69O0+DguCPCkDW+uUdnjGWB8kb01J6jo3Trk="
+          "range": "bytes=4975-85664",
+          "checksum": "sha256-9We1PouJmJHSgYkQtUAXPjxDb2ihIXdPbL9IxfEob4g="
         },
-        "checksum": "Q1eY5w1Fo9xL3drNiqZKlle/V4F0Y="
+        "checksum": "Q1MPXmrT/Y0Us4tb3Sunsj3I4O/fs="
       },
       {
         "name": "git",
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.49.0-r1.apk",
-        "version": "2.49.0-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.50.1-r1.apk",
+        "version": "2.50.1-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5522",
-          "checksum": "sha1-46SkSuViQ6gFD7/szwGUg+nft4Y="
+          "range": "bytes=0-9494",
+          "checksum": "sha1-i5/7WNonRCDjZIVSvGaaToyN/hA="
         },
         "data": {
-          "range": "bytes=5523-9020287",
-          "checksum": "sha256-CV5YivTKFvyfRnUgyQok+4PSANe9EqLdZtAfcfdox1I="
+          "range": "bytes=9495-9052861",
+          "checksum": "sha256-AQ7ye/3SLomEBxvCdfs5X1eegd00z+JBaIr431ROvMQ="
         },
-        "checksum": "Q146SkSuViQ6gFD7/szwGUg+nft4Y="
+        "checksum": "Q1i5/7WNonRCDjZIVSvGaaToyN/hA="
       },
       {
         "name": "oniguruma",
@@ -1789,269 +1789,269 @@
       },
       {
         "name": "jq",
-        "url": "https://packages.wolfi.dev/os/x86_64/jq-1.7.1-r5.apk",
-        "version": "1.7.1-r5",
+        "url": "https://packages.wolfi.dev/os/x86_64/jq-1.8.1-r2.apk",
+        "version": "1.8.1-r2",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6428",
-          "checksum": "sha1-SSoznTLSrAj7DM8NRrQLgFGJH+4="
+          "range": "bytes=0-7014",
+          "checksum": "sha1-jGRxAa1ai6lW9WZrieRlnmTt8Ek="
         },
         "data": {
-          "range": "bytes=6429-405791",
-          "checksum": "sha256-pBiKrNQqi47nMaGSBLzjG/dv19ndVWbG2FWFqzwlYaQ="
+          "range": "bytes=7015-234007",
+          "checksum": "sha256-IIUUe96niE1ErEHkhbrv0oaIbHAvregogmpdeQObsgw="
         },
-        "checksum": "Q1SSoznTLSrAj7DM8NRrQLgFGJH+4="
+        "checksum": "Q1jGRxAa1ai6lW9WZrieRlnmTt8Ek="
       },
       {
         "name": "less",
-        "url": "https://packages.wolfi.dev/os/x86_64/less-678-r0.apk",
-        "version": "678-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/less-681-r1.apk",
+        "version": "681-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5074",
-          "checksum": "sha1-gOcB5VIML2B/vA5vjwwPcEVzP/A="
+          "range": "bytes=0-5818",
+          "checksum": "sha1-v66Bfrhzh5M1Ge1+I4D8xt3tOjQ="
         },
         "data": {
-          "range": "bytes=5075-157507",
-          "checksum": "sha256-ZdZzcrjf5QOXDMx66N9vLRhDcM7J2SUBLItj5vU6B5s="
+          "range": "bytes=5819-159540",
+          "checksum": "sha256-r6phfy50TteccyLn+mlmYBVERNOqnDrFJdmQTWdieMc="
         },
-        "checksum": "Q1gOcB5VIML2B/vA5vjwwPcEVzP/A="
+        "checksum": "Q1v66Bfrhzh5M1Ge1+I4D8xt3tOjQ="
       },
       {
         "name": "libedit",
-        "url": "https://packages.wolfi.dev/os/x86_64/libedit-3.1-r8.apk",
-        "version": "3.1-r8",
+        "url": "https://packages.wolfi.dev/os/x86_64/libedit-3.1-r13.apk",
+        "version": "3.1-r13",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-3867",
-          "checksum": "sha1-FYUVLbMnQzUcDMUF5KZk/RYqrAg="
+          "range": "bytes=0-4684",
+          "checksum": "sha1-ijXOKZikfr4o35/o8PY7bRq84Ds="
         },
         "data": {
-          "range": "bytes=3868-114673",
-          "checksum": "sha256-PMDv9nQqHh3+YfYDJxOom+ZddTljWXn3J3Zwd9IAMpw="
+          "range": "bytes=4685-115660",
+          "checksum": "sha256-Iu3gMQSATx/lcK+Zep61gMKgRT6lpYpCCyfEfj8xjGM="
         },
-        "checksum": "Q1FYUVLbMnQzUcDMUF5KZk/RYqrAg="
+        "checksum": "Q1ijXOKZikfr4o35/o8PY7bRq84Ds="
       },
       {
         "name": "openssh-client",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssh-client-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-client-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4762",
-          "checksum": "sha1-CeKI/n+cELFTWn8CMYJabN7i4+M="
+          "range": "bytes=0-4861",
+          "checksum": "sha1-fmkim0TQ7Nn7+TSsv2X4hPFqP78="
         },
         "data": {
-          "range": "bytes=4763-1123468",
-          "checksum": "sha256-WKcif5tSuzmiTEnywDVHJo4F+GRhWoQ4qvQsJ7jVWNw="
+          "range": "bytes=4862-1133695",
+          "checksum": "sha256-YEfZOk9cgeChCzYbAqnxfFkBXI2Qecd3jfuqKqY4Cl0="
         },
-        "checksum": "Q1CeKI/n+cELFTWn8CMYJabN7i4+M="
+        "checksum": "Q1fmkim0TQ7Nn7+TSsv2X4hPFqP78="
       },
       {
         "name": "libsepol",
-        "url": "https://packages.wolfi.dev/os/x86_64/libsepol-3.8.1-r2.apk",
-        "version": "3.8.1-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/libsepol-3.9-r1.apk",
+        "version": "3.9-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5007",
-          "checksum": "sha1-QxO7f/MisXPHEwHa+H76DNYHZwU="
+          "range": "bytes=0-5155",
+          "checksum": "sha1-ppFXuA3Zl0u8MGw+fIH9xJeDkXQ="
         },
         "data": {
-          "range": "bytes=5008-433597",
-          "checksum": "sha256-FuZcljZ4OZBOXhGDwuerUEnMQw47vq0orJnrP30V/r4="
+          "range": "bytes=5156-438231",
+          "checksum": "sha256-f1sW7pF/ZxmgdKJwPGETprAqmF4cssWPIV7FstqjRw8="
         },
-        "checksum": "Q1QxO7f/MisXPHEwHa+H76DNYHZwU="
+        "checksum": "Q1ppFXuA3Zl0u8MGw+fIH9xJeDkXQ="
       },
       {
         "name": "libselinux",
-        "url": "https://packages.wolfi.dev/os/x86_64/libselinux-3.8.1-r40.apk",
-        "version": "3.8.1-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/libselinux-3.9-r1.apk",
+        "version": "3.9-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6424",
-          "checksum": "sha1-6H0Tsycnw6zou4AhtT5Moj7re4o="
+          "range": "bytes=0-6528",
+          "checksum": "sha1-0bVAUjCl/D35fpdyf78Y3jsNzGo="
         },
         "data": {
-          "range": "bytes=6425-315832",
-          "checksum": "sha256-l8xfKXaJFOndzr16HyRivMbFKostYW99AiiuWV9Ev3g="
+          "range": "bytes=6529-317447",
+          "checksum": "sha256-KlA5zXxnsD5nwz5AZGzJvR75VfHO2HTB47Bp7vJ2pHY="
         },
-        "checksum": "Q16H0Tsycnw6zou4AhtT5Moj7re4o="
+        "checksum": "Q10bVAUjCl/D35fpdyf78Y3jsNzGo="
       },
       {
         "name": "linux-pam",
-        "url": "https://packages.wolfi.dev/os/x86_64/linux-pam-1.7.0-r40.apk",
-        "version": "1.7.0-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/linux-pam-1.7.1-r1.apk",
+        "version": "1.7.1-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-3803",
-          "checksum": "sha1-O/ZO4fE04GGMGOunjviz9sUhpJE="
+          "range": "bytes=0-3913",
+          "checksum": "sha1-6ZEIb6qzruLzpSffzExG+hvGLfo="
         },
         "data": {
-          "range": "bytes=3804-868172",
-          "checksum": "sha256-cPtLMqFSJ+p4Jztyef78K5HN1W8JtoCmnYkOPl4la3w="
+          "range": "bytes=3914-884368",
+          "checksum": "sha256-PwMFW/fHrmAgK2dL3c7qTXDAwmDD5HqimczQDKKrOXM="
         },
-        "checksum": "Q1O/ZO4fE04GGMGOunjviz9sUhpJE="
+        "checksum": "Q16ZEIb6qzruLzpSffzExG+hvGLfo="
       },
       {
         "name": "openssh-server-config",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssh-server-config-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-server-config-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4686",
-          "checksum": "sha1-SR3MZUyaFpWVeTekNAXCbRoUuDU="
+          "range": "bytes=0-4782",
+          "checksum": "sha1-N+nomreiC3ykVOSlgHcMC5IZ7kw="
         },
         "data": {
-          "range": "bytes=4687-7533",
-          "checksum": "sha256-0l8M7qdjJqhbhmCR18fyYf8iogl4tm6yBpwFaIGEo00="
+          "range": "bytes=4783-7745",
+          "checksum": "sha256-gcDlRQ8btxCUIkZ7gBhcAxNOpTJjDQi7FriYZZNK/6Q="
         },
-        "checksum": "Q1SR3MZUyaFpWVeTekNAXCbRoUuDU="
+        "checksum": "Q1N+nomreiC3ykVOSlgHcMC5IZ7kw="
       },
       {
         "name": "openssh-keygen",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssh-keygen-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-keygen-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4732",
-          "checksum": "sha1-gzocEo8AZ6oK7+u3jTV4RwlDMmw="
+          "range": "bytes=0-4832",
+          "checksum": "sha1-DHT5SXIxqtC4OQkO/ZOPqF3IKB4="
         },
         "data": {
-          "range": "bytes=4733-265213",
-          "checksum": "sha256-YlbogiS4UgEF58U7RRmNApTrQX3+uty8HQG5LTJ8YVs="
+          "range": "bytes=4833-267106",
+          "checksum": "sha256-H9uerXjobEn68TajCTXYLEJJzpSyJP7TYc5383/1sG8="
         },
-        "checksum": "Q1gzocEo8AZ6oK7+u3jTV4RwlDMmw="
+        "checksum": "Q1DHT5SXIxqtC4OQkO/ZOPqF3IKB4="
       },
       {
         "name": "openssh-server",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssh-server-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-server-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4801",
-          "checksum": "sha1-4SSL4zoVB2vb9jPHiZ03cvtEWJM="
+          "range": "bytes=0-4901",
+          "checksum": "sha1-sLZ6ltKreI9V8PyalmFHLyA6Yak="
         },
         "data": {
-          "range": "bytes=4802-1241111",
-          "checksum": "sha256-fSi3T66nbS57qPU0/SnJ7WA5k2qwVR7ms8wE4cdkkvA="
+          "range": "bytes=4902-1260254",
+          "checksum": "sha256-S1xMvuQ1dWJqjZvqO/LjN9LjDm1j03WdbGyyX1BbY6s="
         },
-        "checksum": "Q14SSL4zoVB2vb9jPHiZ03cvtEWJM="
+        "checksum": "Q1sLZ6ltKreI9V8PyalmFHLyA6Yak="
       },
       {
         "name": "openssh-sftp-server",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssh-sftp-server-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-sftp-server-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4716",
-          "checksum": "sha1-cTnE0DyGCVC2Dp/0UDaTbJc3+4Q="
+          "range": "bytes=0-4818",
+          "checksum": "sha1-s2KkXkaWFu4rrVoocdjlqqpk82U="
         },
         "data": {
-          "range": "bytes=4717-87156",
-          "checksum": "sha256-9KjUT6QCwd6ALgNgxeHlG8cPm7n7GgH11xpyKKoaOw8="
+          "range": "bytes=4819-87267",
+          "checksum": "sha256-4S2CDU/VMxZVF4vcN2TiRpjkXMkXgUHakLN0FUF8ctc="
         },
-        "checksum": "Q1cTnE0DyGCVC2Dp/0UDaTbJc3+4Q="
+        "checksum": "Q1s2KkXkaWFu4rrVoocdjlqqpk82U="
       },
       {
         "name": "openssh",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssh-10.0_p1-r0.apk",
-        "version": "10.0_p1-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-10.0_p1-r4.apk",
+        "version": "10.0_p1-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-4696",
-          "checksum": "sha1-8t6t/X0S8C+3FnLpU0oqpiSQ0cE="
+          "range": "bytes=0-4795",
+          "checksum": "sha1-QnnLDfEpr+1eiotSyw3BBEEe1K8="
         },
         "data": {
-          "range": "bytes=4697-5957",
-          "checksum": "sha256-SMnqmwUhpyC+yhVYdNk8jkyijDnvWYhaP+sYAaZXfiM="
+          "range": "bytes=4796-6171",
+          "checksum": "sha256-ht6OFggtT+O7SybQHcSWZUsO/zNRm2qQrwUnRymRpgU="
         },
-        "checksum": "Q18t6t/X0S8C+3FnLpU0oqpiSQ0cE="
+        "checksum": "Q1QnnLDfEpr+1eiotSyw3BBEEe1K8="
       },
       {
         "name": "openssl",
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8965",
-          "checksum": "sha1-ZVOvP9eSkJ4qDzYsPhEdXthwHuw="
+          "range": "bytes=0-9089",
+          "checksum": "sha1-XDD5ZZu0o+CsxiKc9hJ9/l1U5RY="
         },
         "data": {
-          "range": "bytes=8966-455644",
-          "checksum": "sha256-EtjadBLrxGtGNRNudXSclFdK/5q7pRQsFdAMTLD7fDk="
+          "range": "bytes=9090-457293",
+          "checksum": "sha256-4erkLIktFt1X3RW/Cj5m27w4AzPuhZGnLUMGa36Ms0Q="
         },
-        "checksum": "Q1ZVOvP9eSkJ4qDzYsPhEdXthwHuw="
+        "checksum": "Q1XDD5ZZu0o+CsxiKc9hJ9/l1U5RY="
       },
       {
         "name": "unzip",
-        "url": "https://packages.wolfi.dev/os/x86_64/unzip-6.0-r1.apk",
-        "version": "6.0-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/unzip-6.0-r3.apk",
+        "version": "6.0-r3",
         "architecture": "x86_64",
         "signature": {
-          "range": "bytes=0-695",
-          "checksum": "sha1-FNEtzDGQapV+/eCC1i+37olbhK4="
+          "range": "",
+          "checksum": ""
         },
         "control": {
-          "range": "bytes=696-1106",
-          "checksum": "sha1-1xoNb55j6R9jQnxKlVK0cW9TaHM="
+          "range": "bytes=0-3025",
+          "checksum": "sha1-smGmw0CzXbwEX8y234LmUrXlG40="
         },
         "data": {
-          "range": "bytes=1107-134903",
-          "checksum": "sha256-U1QqJZGrGnlwIe/iu7MVwplXdpgDTir1NvAENhRQNIg="
+          "range": "bytes=3026-207810",
+          "checksum": "sha256-cRv3NscdWnsZmpVNpYabHOwmC5wXYq7NBmztrnPdHK8="
         },
-        "checksum": "Q11xoNb55j6R9jQnxKlVK0cW9TaHM="
+        "checksum": "Q1smGmw0CzXbwEX8y234LmUrXlG40="
       }
     ]
   }

--- a/examples/oci/apko.lock.json
+++ b/examples/oci/apko.lock.json
@@ -1,7 +1,7 @@
 {
   "version": "v1",
   "config": {
-    "name": "examples/oci/apko.yaml",
+    "name": "./examples/oci/apko.yaml",
     "checksum": "sha256-yP8F/uo2MPwx+QhxlvS1+q+RdzxeuVJ6bAe3uaPuNdc="
   },
   "contents": {
@@ -27,269 +27,269 @@
     "packages": [
       {
         "name": "wolfi-keys",
-        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-keys-1-r10.apk",
-        "version": "1-r10",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-keys-1-r12.apk",
+        "version": "1-r12",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1403",
-          "checksum": "sha1-SDBXedx2uf6jx0Hl6tzyR5U7zKA="
+          "range": "bytes=0-1503",
+          "checksum": "sha1-D3jXYYV6pWMUcYSHJ0Ni0ZdNXYE="
         },
         "data": {
-          "range": "bytes=1404-3420",
-          "checksum": "sha256-99GIo9D1v14ljpnhvzuc/4nW19KXfVy2S+naBnDeEKU="
+          "range": "bytes=1504-3586",
+          "checksum": "sha256-qYN+R7SI7+XEEfSO/EpZ5KD/Zpp8Q/4VpMGPbN2t/FQ="
         },
-        "checksum": "Q1SDBXedx2uf6jx0Hl6tzyR5U7zKA="
+        "checksum": "Q1D3jXYYV6pWMUcYSHJ0Ni0ZdNXYE="
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r20.apk",
-        "version": "20230201-r20",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r23.apk",
+        "version": "20230201-r23",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1658",
-          "checksum": "sha1-TLw5hBAy1hwBFm43m8CKTMGqRsg="
+          "range": "bytes=0-1774",
+          "checksum": "sha1-Edys7TY5uMhTMVJFCJoJnyP+fto="
         },
         "data": {
-          "range": "bytes=1659-13087",
-          "checksum": "sha256-dkSH8iqPyo9sUEmojZXTg3a4DGVb31OcVC/8fWWjwQQ="
+          "range": "bytes=1775-13309",
+          "checksum": "sha256-tJMlBeVIuLFjzxKfPNGcf38QRHFcPpWGoYvQuPLXx3I="
         },
-        "checksum": "Q1TLw5hBAy1hwBFm43m8CKTMGqRsg="
+        "checksum": "Q1Edys7TY5uMhTMVJFCJoJnyP+fto="
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20241121-r40.apk",
-        "version": "20241121-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20250619-r5.apk",
+        "version": "20250619-r5",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5319",
-          "checksum": "sha1-JRUE7NylNCVip0FCtXFcEdUZcmI="
+          "range": "bytes=0-6055",
+          "checksum": "sha1-4ciAG6IenxrZ8zuP6H8MCcHnhaA="
         },
         "data": {
-          "range": "bytes=5320-136786",
-          "checksum": "sha256-bbwCnTVU1fkCjqugUi7Va2+2YC7HjfUJ15FLEzw4deM="
+          "range": "bytes=6056-131933",
+          "checksum": "sha256-5AeEJRnl0v4PM9/1FfMCbvk2cMz4/ed9yRmI2gP6iFw="
         },
-        "checksum": "Q1JRUE7NylNCVip0FCtXFcEdUZcmI="
+        "checksum": "Q14ciAG6IenxrZ8zuP6H8MCcHnhaA="
       },
       {
         "name": "libgcc",
-        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-14.2.0-r12.apk",
-        "version": "14.2.0-r12",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-15.2.0-r0.apk",
+        "version": "15.2.0-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5854",
-          "checksum": "sha1-HXzOXIA/woAXuF62jkq/SELUNiQ="
+          "range": "bytes=0-6108",
+          "checksum": "sha1-ae+NYzcQ2s4ShUbNcIn4JxTEBvU="
         },
         "data": {
-          "range": "bytes=5855-83420",
-          "checksum": "sha256-0rf4Mp+QMnjY0H7p3F/+Ik1lX/B2dSNA7nN67j1afMQ="
+          "range": "bytes=6109-82449",
+          "checksum": "sha256-4T/KUau24R8Ha+ixeJ9okn4/soEYkXAwcQjoos5HPQM="
         },
-        "checksum": "Q1HXzOXIA/woAXuF62jkq/SELUNiQ="
+        "checksum": "Q1ae+NYzcQ2s4ShUbNcIn4JxTEBvU="
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.41-r2.apk",
-        "version": "2.41-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17737",
-          "checksum": "sha1-G21d3h9TsDlXHZnQKXrAJhZmmmI="
+          "range": "bytes=0-13009",
+          "checksum": "sha1-xSvbI2Gen3c6fuysz5AB+jRNB4w="
         },
         "data": {
-          "range": "bytes=17738-124299",
-          "checksum": "sha256-iDYeyvNVIq10qw1yj9O4z/XmLOYH7AUAjrSpIW7jv7U="
+          "range": "bytes=13010-120775",
+          "checksum": "sha256-AnVJlyfi+UoDil9Rmj0+mk7wP29D+YKgltAppZ6/4eE="
         },
-        "checksum": "Q1G21d3h9TsDlXHZnQKXrAJhZmmmI="
+        "checksum": "Q1xSvbI2Gen3c6fuysz5AB+jRNB4w="
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.41-r2.apk",
-        "version": "2.41-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17724",
-          "checksum": "sha1-b05PxA03j1NgjY64YJUSqK/eimM="
+          "range": "bytes=0-12945",
+          "checksum": "sha1-PeF4sNE/zsmFusSMbZYbnq60p04="
         },
         "data": {
-          "range": "bytes=17725-93714",
-          "checksum": "sha256-R7SYkBZO5yIVnDxNGTCVlg8gjAACfu5EtE/li9Dw9x8="
+          "range": "bytes=12946-89071",
+          "checksum": "sha256-lRib43L/TCtBpRHBsFL5U2M0Hi9Pt8wAGwAposReB5w="
         },
-        "checksum": "Q1b05PxA03j1NgjY64YJUSqK/eimM="
+        "checksum": "Q1PeF4sNE/zsmFusSMbZYbnq60p04="
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.41-r2.apk",
-        "version": "2.41-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17863",
-          "checksum": "sha1-JaSBbbF6XdWq6aAMVftJgvF5icg="
+          "range": "bytes=0-13219",
+          "checksum": "sha1-OSa539Q3NJkY16yNFI6fuiIHbmA="
         },
         "data": {
-          "range": "bytes=17864-2099025",
-          "checksum": "sha256-c7VaeGYPJmpXWZ6mmjrB/XtvPq+lOcSVLPry9Lxxmvg="
+          "range": "bytes=13220-2118025",
+          "checksum": "sha256-B5vLVtHJkthCycAh+gjgtwdeTPZ7EWlSxrzpQyMCFyM="
         },
-        "checksum": "Q1JaSBbbF6XdWq6aAMVftJgvF5icg="
+        "checksum": "Q1OSa539Q3NJkY16yNFI6fuiIHbmA="
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.1-r6.apk",
-        "version": "1.3.1-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.1-r51.apk",
+        "version": "1.3.1-r51",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8190",
-          "checksum": "sha1-KioZgEzEWwIOgnFfsOtwFMj61rI="
+          "range": "bytes=0-7324",
+          "checksum": "sha1-tsMFsix2JCqVx/gQd+2yCWxJYSU="
         },
         "data": {
-          "range": "bytes=8191-57550",
-          "checksum": "sha256-VjrCUoUoqKcAEGBptxtQlq6DeGE5LwTHgPYwEnrR6Uw="
+          "range": "bytes=7325-56968",
+          "checksum": "sha256-jASYiEAr7PdGaa+2YwD6gtrSOcUkUh+UZ5I7IQShGQA="
         },
-        "checksum": "Q1KioZgEzEWwIOgnFfsOtwFMj61rI="
+        "checksum": "Q1tsMFsix2JCqVx/gQd+2yCWxJYSU="
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.5.0-r0.apk",
-        "version": "3.5.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8968",
-          "checksum": "sha1-wFGeG9WNdSgpotnXRhIhxk6l21M="
+          "range": "bytes=0-9099",
+          "checksum": "sha1-GoUojkaCyWJgmuiKsHvN/dDcCGw="
         },
         "data": {
-          "range": "bytes=8969-2159527",
-          "checksum": "sha256-U6zriVUvH+i/pjDTi0OpjOgRBGwl3tsG3IZg2ZM/Jy0="
+          "range": "bytes=9100-2138928",
+          "checksum": "sha256-3YCbzj87t4sd1akgNQhsI/SSKZv3iwWUoAHX00lx/68="
         },
-        "checksum": "Q1wFGeG9WNdSgpotnXRhIhxk6l21M="
+        "checksum": "Q1GoUojkaCyWJgmuiKsHvN/dDcCGw="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.5.0-r0.apk",
-        "version": "3.5.0-r0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8973",
-          "checksum": "sha1-8MCiRsYfW5vtn2gL4WLj2zKVxGo="
+          "range": "bytes=0-9098",
+          "checksum": "sha1-INRxoI0GWtbnXLVpUzTIaI1jt2s="
         },
         "data": {
-          "range": "bytes=8974-480955",
-          "checksum": "sha256-X5TSB8O48IAADNonQG9RdQ0Bo63DXzZT1HrcrF3dZN0="
+          "range": "bytes=9099-481348",
+          "checksum": "sha256-imcvx13ksizOkEspSC39rujmac4j4NRqjjF2FDS5900="
         },
-        "checksum": "Q18MCiRsYfW5vtn2gL4WLj2zKVxGo="
+        "checksum": "Q1INRxoI0GWtbnXLVpUzTIaI1jt2s="
       },
       {
         "name": "apk-tools",
-        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.10-r2.apk",
-        "version": "2.14.10-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.10-r7.apk",
+        "version": "2.14.10-r7",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7622",
-          "checksum": "sha1-hYr2c2phiBX7t1Ekdz+rH8bcGnc="
+          "range": "bytes=0-7045",
+          "checksum": "sha1-xBp+iWfglV3SbfZ8iDYJas6Sd8A="
         },
         "data": {
-          "range": "bytes=7623-179215",
-          "checksum": "sha256-HNLblqt7b62mfPTKEJayJjRQVgBA52FlUOU2NqpL+TA="
+          "range": "bytes=7046-177872",
+          "checksum": "sha256-sPiVtySUA2lC6nzMqLQoe5dFlK8l8knPw5TSHk3+MJM="
         },
-        "checksum": "Q1hYr2c2phiBX7t1Ekdz+rH8bcGnc="
+        "checksum": "Q1xBp+iWfglV3SbfZ8iDYJas6Sd8A="
       },
       {
         "name": "libxcrypt",
-        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.4.38-r1.apk",
-        "version": "4.4.38-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.4.38-r4.apk",
+        "version": "4.4.38-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7076",
-          "checksum": "sha1-i7EeMEZa76E7N+tCZDiY/B4uhs4="
+          "range": "bytes=0-6703",
+          "checksum": "sha1-rKT6keIQZNPRUjOjvtdgqc5LUdY="
         },
         "data": {
-          "range": "bytes=7077-99985",
-          "checksum": "sha256-c8nAYv/WmQi+a3RuOrPEMgjVD0+2j4UomQpHxPxB1uM="
+          "range": "bytes=6704-95241",
+          "checksum": "sha256-4d8Bv/OKk8bLzSV/mhJAkHnulhpQh1SHruDNryMvYck="
         },
-        "checksum": "Q1i7EeMEZa76E7N+tCZDiY/B4uhs4="
+        "checksum": "Q1rKT6keIQZNPRUjOjvtdgqc5LUdY="
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.41-r2.apk",
-        "version": "2.41-r2",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17771",
-          "checksum": "sha1-GtcnmJppzHbsEhrqi5oKS0EfJto="
+          "range": "bytes=0-12991",
+          "checksum": "sha1-5AvhwjxXWvorXLOez+bNUlzX9Z0="
         },
         "data": {
-          "range": "bytes=17772-18913",
-          "checksum": "sha256-GyS3SC8xnZaYCugPoXrmjdjrvHBFlO3dW1Ploxh+pWY="
+          "range": "bytes=12992-14272",
+          "checksum": "sha256-PAaoOTo0ceSJQCnvcu6Az066HrKryWEpJ2ZHBg6l7/s="
         },
-        "checksum": "Q1GtcnmJppzHbsEhrqi5oKS0EfJto="
+        "checksum": "Q15AvhwjxXWvorXLOez+bNUlzX9Z0="
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r40.apk",
-        "version": "1.37.0-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r48.apk",
+        "version": "1.37.0-r48",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6285",
-          "checksum": "sha1-gMvK6tCS0Pw0RLXpjAtSyPSNocc="
+          "range": "bytes=0-6390",
+          "checksum": "sha1-kaHpN1iTRpArTRK84g3Q+cyM478="
         },
         "data": {
-          "range": "bytes=6286-432192",
-          "checksum": "sha256-FKVvv946EX6oH5zOsTaS3AtcrXSIzjih3mYM8ajyi4g="
+          "range": "bytes=6391-425623",
+          "checksum": "sha256-VZWQA8qLD6hYCv84k6pVRJFBBk7f0vUr0fbiIArPwbY="
         },
-        "checksum": "Q1gMvK6tCS0Pw0RLXpjAtSyPSNocc="
+        "checksum": "Q1kaHpN1iTRpArTRK84g3Q+cyM478="
       },
       {
         "name": "wolfi-base",
@@ -312,269 +312,269 @@
       },
       {
         "name": "wolfi-keys",
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-keys-1-r10.apk",
-        "version": "1-r10",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-keys-1-r12.apk",
+        "version": "1-r12",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1373",
-          "checksum": "sha1-+/2+kXthuvoBJrdLiWL2teRkX8s="
+          "range": "bytes=0-1475",
+          "checksum": "sha1-xNA/nsDJ5MQRr8ikDwurJvcGWNs="
         },
         "data": {
-          "range": "bytes=1374-3389",
-          "checksum": "sha256-akgwZ5cu+Cykm7WDvC3JPY/DsNPNfldJJMnUCdTOLm0="
+          "range": "bytes=1476-3561",
+          "checksum": "sha256-jL8atxrQaT0XeHIAHY0K1PkEyyR0kkdDUERpc7EkPR0="
         },
-        "checksum": "Q1+/2+kXthuvoBJrdLiWL2teRkX8s="
+        "checksum": "Q1xNA/nsDJ5MQRr8ikDwurJvcGWNs="
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r20.apk",
-        "version": "20230201-r20",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r23.apk",
+        "version": "20230201-r23",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1628",
-          "checksum": "sha1-13r0mEPRLFoMGaeH7lUbK+eLOto="
+          "range": "bytes=0-1743",
+          "checksum": "sha1-5GKR2cusJFuJW5jYQBxRRQK9xTs="
         },
         "data": {
-          "range": "bytes=1629-13059",
-          "checksum": "sha256-AsquTxi+xNTtxQ+7s3wbWRgvCqzpOg2+uQ+rQGcXG7E="
+          "range": "bytes=1744-13281",
+          "checksum": "sha256-dR349XhAoTV5W5l/P5+zNKf3KdcfnchfEGPQTZh9Eb0="
         },
-        "checksum": "Q113r0mEPRLFoMGaeH7lUbK+eLOto="
+        "checksum": "Q15GKR2cusJFuJW5jYQBxRRQK9xTs="
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20241121-r40.apk",
-        "version": "20241121-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20250619-r5.apk",
+        "version": "20250619-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5278",
-          "checksum": "sha1-SXMRsIH38wqnaJ3OwcMcIbMB5lE="
+          "range": "bytes=0-6015",
+          "checksum": "sha1-tfDipbGD4FekKD/gOgiW/BJVZW0="
         },
         "data": {
-          "range": "bytes=5279-136746",
-          "checksum": "sha256-kdckTWjTwjBnWrkz0ALdoGWjA5VbTvnmok48RnFyrlE="
+          "range": "bytes=6016-131890",
+          "checksum": "sha256-QNAhanIIS8Fii0azPAlI/ZO+St5S87HQOJa8C1W3ir4="
         },
-        "checksum": "Q1SXMRsIH38wqnaJ3OwcMcIbMB5lE="
+        "checksum": "Q1tfDipbGD4FekKD/gOgiW/BJVZW0="
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.41-r2.apk",
-        "version": "2.41-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17722",
-          "checksum": "sha1-iMcjuA4w5vB3vxn+9p/jiNGUssg="
+          "range": "bytes=0-12977",
+          "checksum": "sha1-Q7n3NwDvuB/5QAlLSUvDcg9IbKE="
         },
         "data": {
-          "range": "bytes=17723-146167",
-          "checksum": "sha256-kLRFDAMga2wCHLiETxjJsFJ4FxCA+uy+EJPmzrthgas="
+          "range": "bytes=12978-142179",
+          "checksum": "sha256-MatFN+S2wR1mXGo4xi4dwBJpQw3uXVdtiOBtz7p1DiI="
         },
-        "checksum": "Q1iMcjuA4w5vB3vxn+9p/jiNGUssg="
+        "checksum": "Q1Q7n3NwDvuB/5QAlLSUvDcg9IbKE="
       },
       {
         "name": "libgcc",
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-14.2.0-r12.apk",
-        "version": "14.2.0-r12",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-15.2.0-r0.apk",
+        "version": "15.2.0-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5832",
-          "checksum": "sha1-FcC3c+uEDjXLs3SPvcflXelPGL8="
+          "range": "bytes=0-6085",
+          "checksum": "sha1-yC91cq07MtdPoSnZ/e4j47KwlLU="
         },
         "data": {
-          "range": "bytes=5833-100428",
-          "checksum": "sha256-zHGFPpQLdFIcW/xXFPusvmv2PzB+kNK2ur0F0NWHAWA="
+          "range": "bytes=6086-100221",
+          "checksum": "sha256-T9demvxVXpVu792wPzUqibp6aQvqtoQyYKreV6vnnOI="
         },
-        "checksum": "Q1FcC3c+uEDjXLs3SPvcflXelPGL8="
+        "checksum": "Q1yC91cq07MtdPoSnZ/e4j47KwlLU="
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.41-r2.apk",
-        "version": "2.41-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17701",
-          "checksum": "sha1-tYjHlo4TkaLZPkJ3OSvyvaXBHHM="
+          "range": "bytes=0-12914",
+          "checksum": "sha1-jysComX6GNf7ds/8F/vdHeUTc3k="
         },
         "data": {
-          "range": "bytes=17702-93693",
-          "checksum": "sha256-Q9GAWVma38QMCe2dO9S7Czyv+1IdUdVH0UVFgJ04Tt0="
+          "range": "bytes=12915-89042",
+          "checksum": "sha256-LGkJ4JQCpggNQNJbepMow5whAc0CyNPbe82R1OgcClk="
         },
-        "checksum": "Q1tYjHlo4TkaLZPkJ3OSvyvaXBHHM="
+        "checksum": "Q1jysComX6GNf7ds/8F/vdHeUTc3k="
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.41-r2.apk",
-        "version": "2.41-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17835",
-          "checksum": "sha1-AnMlTLydcunl+BQ+SOoifkFHyQc="
+          "range": "bytes=0-13173",
+          "checksum": "sha1-n1ty/Fb9oVbFF0nkZp8Av72PLTQ="
         },
         "data": {
-          "range": "bytes=17836-2880437",
-          "checksum": "sha256-FPFxQb8MnBkuFtPG5tYnMyKdzTyJkGoE3/juin3qc0o="
+          "range": "bytes=13174-2893419",
+          "checksum": "sha256-HUtm178rjNrcoXEfGzmxvmJpqhW4GPjlElHBChBk1bY="
         },
-        "checksum": "Q1AnMlTLydcunl+BQ+SOoifkFHyQc="
+        "checksum": "Q1n1ty/Fb9oVbFF0nkZp8Av72PLTQ="
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r6.apk",
-        "version": "1.3.1-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r51.apk",
+        "version": "1.3.1-r51",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8151",
-          "checksum": "sha1-WC5ueST8mSvu2Vq5aGscl+br858="
+          "range": "bytes=0-7282",
+          "checksum": "sha1-/kfcansNYm3y06m+tgXyDJMjPqs="
         },
         "data": {
-          "range": "bytes=8152-67192",
-          "checksum": "sha256-Y04E/I4Echr0bvvjPfuLqalfCFkYKUiZhOgKrfTDqo0="
+          "range": "bytes=7283-67255",
+          "checksum": "sha256-gthB7I68g/ezQRlM7Z3bkM8KhxgqwSHxu4RqF5xscKE="
         },
-        "checksum": "Q1WC5ueST8mSvu2Vq5aGscl+br858="
+        "checksum": "Q1/kfcansNYm3y06m+tgXyDJMjPqs="
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.5.0-r0.apk",
-        "version": "3.5.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8935",
-          "checksum": "sha1-Vb6uRJ8h8/aTvDYeX9UeIVAkKFU="
+          "range": "bytes=0-9065",
+          "checksum": "sha1-kFScXMyqaOaaYNq1OBKYyP0znY0="
         },
         "data": {
-          "range": "bytes=8936-2295854",
-          "checksum": "sha256-O+JmrmI3cbGMdDgCkQQhLEelOSi0UIErJdOZ9eRg33I="
+          "range": "bytes=9066-2309962",
+          "checksum": "sha256-3wXCRnY+O3Q8cVEQqihb7wn9NaJ30mImMvyKQly3xrQ="
         },
-        "checksum": "Q1Vb6uRJ8h8/aTvDYeX9UeIVAkKFU="
+        "checksum": "Q1kFScXMyqaOaaYNq1OBKYyP0znY0="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.5.0-r0.apk",
-        "version": "3.5.0-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8936",
-          "checksum": "sha1-T/lNY2euvgAfq2J3KQWWtSt1+a4="
+          "range": "bytes=0-9073",
+          "checksum": "sha1-3KUYsFYdhVMxnC16CoycflTDIVo="
         },
         "data": {
-          "range": "bytes=8937-487923",
-          "checksum": "sha256-MraurFYPGXz3HMdIWpNbsnYJotucst0lOKjc+ecnous="
+          "range": "bytes=9074-494008",
+          "checksum": "sha256-cUBmJ+dt7HeAsHFlR79EYt9GflWS95k3OTP78FdD03Q="
         },
-        "checksum": "Q1T/lNY2euvgAfq2J3KQWWtSt1+a4="
+        "checksum": "Q13KUYsFYdhVMxnC16CoycflTDIVo="
       },
       {
         "name": "apk-tools",
-        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.10-r2.apk",
-        "version": "2.14.10-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.10-r7.apk",
+        "version": "2.14.10-r7",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7598",
-          "checksum": "sha1-1IGGSLJs/7LAUku0YlK521mWxNQ="
+          "range": "bytes=0-7023",
+          "checksum": "sha1-M6ISpMsBPkPMJTEOxf2+KvBTCeg="
         },
         "data": {
-          "range": "bytes=7599-178188",
-          "checksum": "sha256-izNqQzyTXKA3BFExUEeh2jRimi2fRzFS+RSmmE30xfk="
+          "range": "bytes=7024-178934",
+          "checksum": "sha256-e2rfTRGjOf35RxWsiUR5pEbijaKPJB0p/bfIAh+Wmjk="
         },
-        "checksum": "Q11IGGSLJs/7LAUku0YlK521mWxNQ="
+        "checksum": "Q1M6ISpMsBPkPMJTEOxf2+KvBTCeg="
       },
       {
         "name": "libxcrypt",
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.38-r1.apk",
-        "version": "4.4.38-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.38-r4.apk",
+        "version": "4.4.38-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7034",
-          "checksum": "sha1-ZHBMgu6bunisUBcF0R3YEQZc7Hw="
+          "range": "bytes=0-6666",
+          "checksum": "sha1-ARKVRod69JglgHYfA7Jjs1yigts="
         },
         "data": {
-          "range": "bytes=7035-92050",
-          "checksum": "sha256-eKW+wshn3K1zp4ZXVVwW0ntXeH24dQs1kuKq4i/iF5E="
+          "range": "bytes=6667-92460",
+          "checksum": "sha256-jTHfNR1n0LPpgRNPfcjXoM2v1ur/DWbodQHZHpmRF3s="
         },
-        "checksum": "Q1ZHBMgu6bunisUBcF0R3YEQZc7Hw="
+        "checksum": "Q1ARKVRod69JglgHYfA7Jjs1yigts="
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.41-r2.apk",
-        "version": "2.41-r2",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17740",
-          "checksum": "sha1-lcO6rMlx971lINGvLwoJVgzNTAA="
+          "range": "bytes=0-12966",
+          "checksum": "sha1-oX0abHV9oimmFr7yir0v3+yeszY="
         },
         "data": {
-          "range": "bytes=17741-18882",
-          "checksum": "sha256-UzO7uB9bf5CgMoYo6xT13jKPzL4FnJTfEjt1kiqWn08="
+          "range": "bytes=12967-14248",
+          "checksum": "sha256-B0pkEypiYdEuLqSlbgk6LaCd5X4LwOTLfXItZ7N7PD4="
         },
-        "checksum": "Q1lcO6rMlx971lINGvLwoJVgzNTAA="
+        "checksum": "Q1oX0abHV9oimmFr7yir0v3+yeszY="
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r40.apk",
-        "version": "1.37.0-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r48.apk",
+        "version": "1.37.0-r48",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6256",
-          "checksum": "sha1-LInTlXp+HUmKix0sbwTHmV440Qc="
+          "range": "bytes=0-6365",
+          "checksum": "sha1-25Lnt5/Z++DnCtkcDTl9k2YMg5I="
         },
         "data": {
-          "range": "bytes=6257-422224",
-          "checksum": "sha256-3r9aMobGULBrS0sQCI604/ZvzpzMmXBzr06esybQWlU="
+          "range": "bytes=6366-422440",
+          "checksum": "sha256-dSxSIv2DXO2mQ6isMDg860IVUU4BeVytENJWUV/W/bI="
         },
-        "checksum": "Q1LInTlXp+HUmKix0sbwTHmV440Qc="
+        "checksum": "Q125Lnt5/Z++DnCtkcDTl9k2YMg5I="
       },
       {
         "name": "wolfi-base",

--- a/examples/wolfi-base/apko.lock.json
+++ b/examples/wolfi-base/apko.lock.json
@@ -27,269 +27,269 @@
     "packages": [
       {
         "name": "wolfi-keys",
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-keys-1-r10.apk",
-        "version": "1-r10",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-keys-1-r12.apk",
+        "version": "1-r12",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1373",
-          "checksum": "sha1-+/2+kXthuvoBJrdLiWL2teRkX8s="
+          "range": "bytes=0-1475",
+          "checksum": "sha1-xNA/nsDJ5MQRr8ikDwurJvcGWNs="
         },
         "data": {
-          "range": "bytes=1374-3389",
-          "checksum": "sha256-akgwZ5cu+Cykm7WDvC3JPY/DsNPNfldJJMnUCdTOLm0="
+          "range": "bytes=1476-3561",
+          "checksum": "sha256-jL8atxrQaT0XeHIAHY0K1PkEyyR0kkdDUERpc7EkPR0="
         },
-        "checksum": "Q1+/2+kXthuvoBJrdLiWL2teRkX8s="
+        "checksum": "Q1xNA/nsDJ5MQRr8ikDwurJvcGWNs="
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r20.apk",
-        "version": "20230201-r20",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r23.apk",
+        "version": "20230201-r23",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1628",
-          "checksum": "sha1-13r0mEPRLFoMGaeH7lUbK+eLOto="
+          "range": "bytes=0-1743",
+          "checksum": "sha1-5GKR2cusJFuJW5jYQBxRRQK9xTs="
         },
         "data": {
-          "range": "bytes=1629-13059",
-          "checksum": "sha256-AsquTxi+xNTtxQ+7s3wbWRgvCqzpOg2+uQ+rQGcXG7E="
+          "range": "bytes=1744-13281",
+          "checksum": "sha256-dR349XhAoTV5W5l/P5+zNKf3KdcfnchfEGPQTZh9Eb0="
         },
-        "checksum": "Q113r0mEPRLFoMGaeH7lUbK+eLOto="
+        "checksum": "Q15GKR2cusJFuJW5jYQBxRRQK9xTs="
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20241121-r40.apk",
-        "version": "20241121-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20250619-r5.apk",
+        "version": "20250619-r5",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5278",
-          "checksum": "sha1-SXMRsIH38wqnaJ3OwcMcIbMB5lE="
+          "range": "bytes=0-6015",
+          "checksum": "sha1-tfDipbGD4FekKD/gOgiW/BJVZW0="
         },
         "data": {
-          "range": "bytes=5279-136746",
-          "checksum": "sha256-kdckTWjTwjBnWrkz0ALdoGWjA5VbTvnmok48RnFyrlE="
+          "range": "bytes=6016-131890",
+          "checksum": "sha256-QNAhanIIS8Fii0azPAlI/ZO+St5S87HQOJa8C1W3ir4="
         },
-        "checksum": "Q1SXMRsIH38wqnaJ3OwcMcIbMB5lE="
+        "checksum": "Q1tfDipbGD4FekKD/gOgiW/BJVZW0="
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17772",
-          "checksum": "sha1-z6/r5u04ry70FCKAf1bna7uP2hU="
+          "range": "bytes=0-12977",
+          "checksum": "sha1-Q7n3NwDvuB/5QAlLSUvDcg9IbKE="
         },
         "data": {
-          "range": "bytes=17773-704762",
-          "checksum": "sha256-XcBDCrpfoSjyHMJ4mWeUPb/ACQXes7E3rlL3MGehCHk="
+          "range": "bytes=12978-142179",
+          "checksum": "sha256-MatFN+S2wR1mXGo4xi4dwBJpQw3uXVdtiOBtz7p1DiI="
         },
-        "checksum": "Q1z6/r5u04ry70FCKAf1bna7uP2hU="
+        "checksum": "Q1Q7n3NwDvuB/5QAlLSUvDcg9IbKE="
       },
       {
         "name": "libgcc",
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-14.2.0-r12.apk",
-        "version": "14.2.0-r12",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-15.2.0-r0.apk",
+        "version": "15.2.0-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5832",
-          "checksum": "sha1-FcC3c+uEDjXLs3SPvcflXelPGL8="
+          "range": "bytes=0-6085",
+          "checksum": "sha1-yC91cq07MtdPoSnZ/e4j47KwlLU="
         },
         "data": {
-          "range": "bytes=5833-100428",
-          "checksum": "sha256-zHGFPpQLdFIcW/xXFPusvmv2PzB+kNK2ur0F0NWHAWA="
+          "range": "bytes=6086-100221",
+          "checksum": "sha256-T9demvxVXpVu792wPzUqibp6aQvqtoQyYKreV6vnnOI="
         },
-        "checksum": "Q1FcC3c+uEDjXLs3SPvcflXelPGL8="
+        "checksum": "Q1yC91cq07MtdPoSnZ/e4j47KwlLU="
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17746",
-          "checksum": "sha1-lXXHntQ/7cTgQnU8gl59jCScE1c="
+          "range": "bytes=0-12914",
+          "checksum": "sha1-jysComX6GNf7ds/8F/vdHeUTc3k="
         },
         "data": {
-          "range": "bytes=17747-93741",
-          "checksum": "sha256-SA47aNAR7uNahlOz5co077i9FBuZcN3f7uSZ4Z2btkY="
+          "range": "bytes=12915-89042",
+          "checksum": "sha256-LGkJ4JQCpggNQNJbepMow5whAc0CyNPbe82R1OgcClk="
         },
-        "checksum": "Q1lXXHntQ/7cTgQnU8gl59jCScE1c="
+        "checksum": "Q1jysComX6GNf7ds/8F/vdHeUTc3k="
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17906",
-          "checksum": "sha1-g2VxUkpuEvo68AKiW6PEC5VuziA="
+          "range": "bytes=0-13173",
+          "checksum": "sha1-n1ty/Fb9oVbFF0nkZp8Av72PLTQ="
         },
         "data": {
-          "range": "bytes=17907-9778110",
-          "checksum": "sha256-izYDuNjcCmipHK630vMoxNRF9OoBWAFLBt7bGpbybLY="
+          "range": "bytes=13174-2893419",
+          "checksum": "sha256-HUtm178rjNrcoXEfGzmxvmJpqhW4GPjlElHBChBk1bY="
         },
-        "checksum": "Q1g2VxUkpuEvo68AKiW6PEC5VuziA="
+        "checksum": "Q1n1ty/Fb9oVbFF0nkZp8Av72PLTQ="
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r6.apk",
-        "version": "1.3.1-r6",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r51.apk",
+        "version": "1.3.1-r51",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8151",
-          "checksum": "sha1-WC5ueST8mSvu2Vq5aGscl+br858="
+          "range": "bytes=0-7282",
+          "checksum": "sha1-/kfcansNYm3y06m+tgXyDJMjPqs="
         },
         "data": {
-          "range": "bytes=8152-67192",
-          "checksum": "sha256-Y04E/I4Echr0bvvjPfuLqalfCFkYKUiZhOgKrfTDqo0="
+          "range": "bytes=7283-67255",
+          "checksum": "sha256-gthB7I68g/ezQRlM7Z3bkM8KhxgqwSHxu4RqF5xscKE="
         },
-        "checksum": "Q1WC5ueST8mSvu2Vq5aGscl+br858="
+        "checksum": "Q1/kfcansNYm3y06m+tgXyDJMjPqs="
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8927",
-          "checksum": "sha1-gmC+Eb40K8Hsw3giUEyq1L4p3gc="
+          "range": "bytes=0-9065",
+          "checksum": "sha1-kFScXMyqaOaaYNq1OBKYyP0znY0="
         },
         "data": {
-          "range": "bytes=8928-2295853",
-          "checksum": "sha256-ZNw3IVWoD9Mej/7+WBpRtC0csC/OgypQ5sxAOtI9tC8="
+          "range": "bytes=9066-2309962",
+          "checksum": "sha256-3wXCRnY+O3Q8cVEQqihb7wn9NaJ30mImMvyKQly3xrQ="
         },
-        "checksum": "Q1gmC+Eb40K8Hsw3giUEyq1L4p3gc="
+        "checksum": "Q1kFScXMyqaOaaYNq1OBKYyP0znY0="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8930",
-          "checksum": "sha1-Dlhg7IYpt5wllRSv1cA7zlnhpyA="
+          "range": "bytes=0-9073",
+          "checksum": "sha1-3KUYsFYdhVMxnC16CoycflTDIVo="
         },
         "data": {
-          "range": "bytes=8931-487922",
-          "checksum": "sha256-QZH47VGlQVtd7SGLiS8wXNTexl39RDAo7VYwU0ttw7w="
+          "range": "bytes=9074-494008",
+          "checksum": "sha256-cUBmJ+dt7HeAsHFlR79EYt9GflWS95k3OTP78FdD03Q="
         },
-        "checksum": "Q1Dlhg7IYpt5wllRSv1cA7zlnhpyA="
+        "checksum": "Q13KUYsFYdhVMxnC16CoycflTDIVo="
       },
       {
         "name": "apk-tools",
-        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.10-r3.apk",
-        "version": "2.14.10-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.10-r7.apk",
+        "version": "2.14.10-r7",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6271",
-          "checksum": "sha1-4yGc6cTFz4JVtRGEasyYfVCh02E="
+          "range": "bytes=0-7023",
+          "checksum": "sha1-M6ISpMsBPkPMJTEOxf2+KvBTCeg="
         },
         "data": {
-          "range": "bytes=6272-177284",
-          "checksum": "sha256-Iy9N9MfYe7Cu0tgzZIKCICatGcm37tM8+cHAkxdF0og="
+          "range": "bytes=7024-178934",
+          "checksum": "sha256-e2rfTRGjOf35RxWsiUR5pEbijaKPJB0p/bfIAh+Wmjk="
         },
-        "checksum": "Q14yGc6cTFz4JVtRGEasyYfVCh02E="
+        "checksum": "Q1M6ISpMsBPkPMJTEOxf2+KvBTCeg="
       },
       {
         "name": "libxcrypt",
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.38-r1.apk",
-        "version": "4.4.38-r1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.38-r4.apk",
+        "version": "4.4.38-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7034",
-          "checksum": "sha1-ZHBMgu6bunisUBcF0R3YEQZc7Hw="
+          "range": "bytes=0-6666",
+          "checksum": "sha1-ARKVRod69JglgHYfA7Jjs1yigts="
         },
         "data": {
-          "range": "bytes=7035-92050",
-          "checksum": "sha256-eKW+wshn3K1zp4ZXVVwW0ntXeH24dQs1kuKq4i/iF5E="
+          "range": "bytes=6667-92460",
+          "checksum": "sha256-jTHfNR1n0LPpgRNPfcjXoM2v1ur/DWbodQHZHpmRF3s="
         },
-        "checksum": "Q1ZHBMgu6bunisUBcF0R3YEQZc7Hw="
+        "checksum": "Q1ARKVRod69JglgHYfA7Jjs1yigts="
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17808",
-          "checksum": "sha1-Ts4nEDCH/Jx2sAd77zFVOQKQn84="
+          "range": "bytes=0-12966",
+          "checksum": "sha1-oX0abHV9oimmFr7yir0v3+yeszY="
         },
         "data": {
-          "range": "bytes=17809-18951",
-          "checksum": "sha256-kLHdS1yw5LrHLVp8o+fN7jmj8KPz9sYZD40ZS26hh34="
+          "range": "bytes=12967-14248",
+          "checksum": "sha256-B0pkEypiYdEuLqSlbgk6LaCd5X4LwOTLfXItZ7N7PD4="
         },
-        "checksum": "Q1Ts4nEDCH/Jx2sAd77zFVOQKQn84="
+        "checksum": "Q1oX0abHV9oimmFr7yir0v3+yeszY="
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r40.apk",
-        "version": "1.37.0-r40",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r48.apk",
+        "version": "1.37.0-r48",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6256",
-          "checksum": "sha1-LInTlXp+HUmKix0sbwTHmV440Qc="
+          "range": "bytes=0-6365",
+          "checksum": "sha1-25Lnt5/Z++DnCtkcDTl9k2YMg5I="
         },
         "data": {
-          "range": "bytes=6257-422224",
-          "checksum": "sha256-3r9aMobGULBrS0sQCI604/ZvzpzMmXBzr06esybQWlU="
+          "range": "bytes=6366-422440",
+          "checksum": "sha256-dSxSIv2DXO2mQ6isMDg860IVUU4BeVytENJWUV/W/bI="
         },
-        "checksum": "Q1LInTlXp+HUmKix0sbwTHmV440Qc="
+        "checksum": "Q125Lnt5/Z++DnCtkcDTl9k2YMg5I="
       },
       {
         "name": "wolfi-base",
@@ -312,269 +312,269 @@
       },
       {
         "name": "wolfi-keys",
-        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-keys-1-r10.apk",
-        "version": "1-r10",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-keys-1-r12.apk",
+        "version": "1-r12",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1403",
-          "checksum": "sha1-SDBXedx2uf6jx0Hl6tzyR5U7zKA="
+          "range": "bytes=0-1503",
+          "checksum": "sha1-D3jXYYV6pWMUcYSHJ0Ni0ZdNXYE="
         },
         "data": {
-          "range": "bytes=1404-3420",
-          "checksum": "sha256-99GIo9D1v14ljpnhvzuc/4nW19KXfVy2S+naBnDeEKU="
+          "range": "bytes=1504-3586",
+          "checksum": "sha256-qYN+R7SI7+XEEfSO/EpZ5KD/Zpp8Q/4VpMGPbN2t/FQ="
         },
-        "checksum": "Q1SDBXedx2uf6jx0Hl6tzyR5U7zKA="
+        "checksum": "Q1D3jXYYV6pWMUcYSHJ0Ni0ZdNXYE="
       },
       {
         "name": "wolfi-baselayout",
-        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r20.apk",
-        "version": "20230201-r20",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r23.apk",
+        "version": "20230201-r23",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-1658",
-          "checksum": "sha1-TLw5hBAy1hwBFm43m8CKTMGqRsg="
+          "range": "bytes=0-1774",
+          "checksum": "sha1-Edys7TY5uMhTMVJFCJoJnyP+fto="
         },
         "data": {
-          "range": "bytes=1659-13087",
-          "checksum": "sha256-dkSH8iqPyo9sUEmojZXTg3a4DGVb31OcVC/8fWWjwQQ="
+          "range": "bytes=1775-13309",
+          "checksum": "sha256-tJMlBeVIuLFjzxKfPNGcf38QRHFcPpWGoYvQuPLXx3I="
         },
-        "checksum": "Q1TLw5hBAy1hwBFm43m8CKTMGqRsg="
+        "checksum": "Q1Edys7TY5uMhTMVJFCJoJnyP+fto="
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20241121-r40.apk",
-        "version": "20241121-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20250619-r5.apk",
+        "version": "20250619-r5",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5319",
-          "checksum": "sha1-JRUE7NylNCVip0FCtXFcEdUZcmI="
+          "range": "bytes=0-6055",
+          "checksum": "sha1-4ciAG6IenxrZ8zuP6H8MCcHnhaA="
         },
         "data": {
-          "range": "bytes=5320-136786",
-          "checksum": "sha256-bbwCnTVU1fkCjqugUi7Va2+2YC7HjfUJ15FLEzw4deM="
+          "range": "bytes=6056-131933",
+          "checksum": "sha256-5AeEJRnl0v4PM9/1FfMCbvk2cMz4/ed9yRmI2gP6iFw="
         },
-        "checksum": "Q1JRUE7NylNCVip0FCtXFcEdUZcmI="
+        "checksum": "Q14ciAG6IenxrZ8zuP6H8MCcHnhaA="
       },
       {
         "name": "libgcc",
-        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-14.2.0-r12.apk",
-        "version": "14.2.0-r12",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-15.2.0-r0.apk",
+        "version": "15.2.0-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-5854",
-          "checksum": "sha1-HXzOXIA/woAXuF62jkq/SELUNiQ="
+          "range": "bytes=0-6108",
+          "checksum": "sha1-ae+NYzcQ2s4ShUbNcIn4JxTEBvU="
         },
         "data": {
-          "range": "bytes=5855-83420",
-          "checksum": "sha256-0rf4Mp+QMnjY0H7p3F/+Ik1lX/B2dSNA7nN67j1afMQ="
+          "range": "bytes=6109-82449",
+          "checksum": "sha256-4T/KUau24R8Ha+ixeJ9okn4/soEYkXAwcQjoos5HPQM="
         },
-        "checksum": "Q1HXzOXIA/woAXuF62jkq/SELUNiQ="
+        "checksum": "Q1ae+NYzcQ2s4ShUbNcIn4JxTEBvU="
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17803",
-          "checksum": "sha1-4wSSJr3IKkGhGt7114TYhqNTLvc="
+          "range": "bytes=0-13009",
+          "checksum": "sha1-xSvbI2Gen3c6fuysz5AB+jRNB4w="
         },
         "data": {
-          "range": "bytes=17804-568869",
-          "checksum": "sha256-P98nRN2+3Zx6SgK6A7e3bJJ6sgPjv5pkQHfoq7dsnCM="
+          "range": "bytes=13010-120775",
+          "checksum": "sha256-AnVJlyfi+UoDil9Rmj0+mk7wP29D+YKgltAppZ6/4eE="
         },
-        "checksum": "Q14wSSJr3IKkGhGt7114TYhqNTLvc="
+        "checksum": "Q1xSvbI2Gen3c6fuysz5AB+jRNB4w="
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17792",
-          "checksum": "sha1-ZrKeDj1SfcZqoJjGYnCq8xqE1uI="
+          "range": "bytes=0-12945",
+          "checksum": "sha1-PeF4sNE/zsmFusSMbZYbnq60p04="
         },
         "data": {
-          "range": "bytes=17793-93786",
-          "checksum": "sha256-BBGZ9QQHsgRa00RSo46pAcAFEgqUDDWPHMtWkSORgDQ="
+          "range": "bytes=12946-89071",
+          "checksum": "sha256-lRib43L/TCtBpRHBsFL5U2M0Hi9Pt8wAGwAposReB5w="
         },
-        "checksum": "Q1ZrKeDj1SfcZqoJjGYnCq8xqE1uI="
+        "checksum": "Q1PeF4sNE/zsmFusSMbZYbnq60p04="
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17937",
-          "checksum": "sha1-vXfsNex2s9L/Eax6Xzh6wcGMfSU="
+          "range": "bytes=0-13219",
+          "checksum": "sha1-OSa539Q3NJkY16yNFI6fuiIHbmA="
         },
         "data": {
-          "range": "bytes=17938-8425800",
-          "checksum": "sha256-OJjcb+88eVPNLAW7usB1fO3Vjg+hDfU3Bx3BVXC3D9g="
+          "range": "bytes=13220-2118025",
+          "checksum": "sha256-B5vLVtHJkthCycAh+gjgtwdeTPZ7EWlSxrzpQyMCFyM="
         },
-        "checksum": "Q1vXfsNex2s9L/Eax6Xzh6wcGMfSU="
+        "checksum": "Q1OSa539Q3NJkY16yNFI6fuiIHbmA="
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.1-r6.apk",
-        "version": "1.3.1-r6",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.1-r51.apk",
+        "version": "1.3.1-r51",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8190",
-          "checksum": "sha1-KioZgEzEWwIOgnFfsOtwFMj61rI="
+          "range": "bytes=0-7324",
+          "checksum": "sha1-tsMFsix2JCqVx/gQd+2yCWxJYSU="
         },
         "data": {
-          "range": "bytes=8191-57550",
-          "checksum": "sha256-VjrCUoUoqKcAEGBptxtQlq6DeGE5LwTHgPYwEnrR6Uw="
+          "range": "bytes=7325-56968",
+          "checksum": "sha256-jASYiEAr7PdGaa+2YwD6gtrSOcUkUh+UZ5I7IQShGQA="
         },
-        "checksum": "Q1KioZgEzEWwIOgnFfsOtwFMj61rI="
+        "checksum": "Q1tsMFsix2JCqVx/gQd+2yCWxJYSU="
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8964",
-          "checksum": "sha1-S5Ad/WGF3WLici60SrCB1YYsLZE="
+          "range": "bytes=0-9099",
+          "checksum": "sha1-GoUojkaCyWJgmuiKsHvN/dDcCGw="
         },
         "data": {
-          "range": "bytes=8965-2159527",
-          "checksum": "sha256-dVnzX3EnJPMRWrN1JIGZ+bqGQRO3Oka2rKCrNW8gIJ8="
+          "range": "bytes=9100-2138928",
+          "checksum": "sha256-3YCbzj87t4sd1akgNQhsI/SSKZv3iwWUoAHX00lx/68="
         },
-        "checksum": "Q1S5Ad/WGF3WLici60SrCB1YYsLZE="
+        "checksum": "Q1GoUojkaCyWJgmuiKsHvN/dDcCGw="
       },
       {
         "name": "libssl3",
-        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.5.0-r1.apk",
-        "version": "3.5.0-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.5.2-r0.apk",
+        "version": "3.5.2-r0",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8966",
-          "checksum": "sha1-vwslUX45jLscd5Hhf6ZuoNnGRfM="
+          "range": "bytes=0-9098",
+          "checksum": "sha1-INRxoI0GWtbnXLVpUzTIaI1jt2s="
         },
         "data": {
-          "range": "bytes=8967-480947",
-          "checksum": "sha256-Ta/BersmN7IocKvjwRv4JhkX7mAXzKqWErlWxjKKnu4="
+          "range": "bytes=9099-481348",
+          "checksum": "sha256-imcvx13ksizOkEspSC39rujmac4j4NRqjjF2FDS5900="
         },
-        "checksum": "Q1vwslUX45jLscd5Hhf6ZuoNnGRfM="
+        "checksum": "Q1INRxoI0GWtbnXLVpUzTIaI1jt2s="
       },
       {
         "name": "apk-tools",
-        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.10-r3.apk",
-        "version": "2.14.10-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.10-r7.apk",
+        "version": "2.14.10-r7",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6295",
-          "checksum": "sha1-8feITZgL4sKBL9Kn5QARGkRA33U="
+          "range": "bytes=0-7045",
+          "checksum": "sha1-xBp+iWfglV3SbfZ8iDYJas6Sd8A="
         },
         "data": {
-          "range": "bytes=6296-178070",
-          "checksum": "sha256-y/4qvrvdCRw4yYHWZKqwbNjGsZec3uFp7oTgf2sAcDY="
+          "range": "bytes=7046-177872",
+          "checksum": "sha256-sPiVtySUA2lC6nzMqLQoe5dFlK8l8knPw5TSHk3+MJM="
         },
-        "checksum": "Q18feITZgL4sKBL9Kn5QARGkRA33U="
+        "checksum": "Q1xBp+iWfglV3SbfZ8iDYJas6Sd8A="
       },
       {
         "name": "libxcrypt",
-        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.4.38-r1.apk",
-        "version": "4.4.38-r1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.4.38-r4.apk",
+        "version": "4.4.38-r4",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7076",
-          "checksum": "sha1-i7EeMEZa76E7N+tCZDiY/B4uhs4="
+          "range": "bytes=0-6703",
+          "checksum": "sha1-rKT6keIQZNPRUjOjvtdgqc5LUdY="
         },
         "data": {
-          "range": "bytes=7077-99985",
-          "checksum": "sha256-c8nAYv/WmQi+a3RuOrPEMgjVD0+2j4UomQpHxPxB1uM="
+          "range": "bytes=6704-95241",
+          "checksum": "sha256-4d8Bv/OKk8bLzSV/mhJAkHnulhpQh1SHruDNryMvYck="
         },
-        "checksum": "Q1i7EeMEZa76E7N+tCZDiY/B4uhs4="
+        "checksum": "Q1rKT6keIQZNPRUjOjvtdgqc5LUdY="
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.41-r3.apk",
-        "version": "2.41-r3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.41-r56.apk",
+        "version": "2.41-r56",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-17827",
-          "checksum": "sha1-ux7LiQpFLvJr9BHwBeWkLCMfHzw="
+          "range": "bytes=0-12991",
+          "checksum": "sha1-5AvhwjxXWvorXLOez+bNUlzX9Z0="
         },
         "data": {
-          "range": "bytes=17828-18968",
-          "checksum": "sha256-MoMJA8U0SxqNOgx+9dTKfI9+lHraTMzXoG2/wl3AqYs="
+          "range": "bytes=12992-14272",
+          "checksum": "sha256-PAaoOTo0ceSJQCnvcu6Az066HrKryWEpJ2ZHBg6l7/s="
         },
-        "checksum": "Q1ux7LiQpFLvJr9BHwBeWkLCMfHzw="
+        "checksum": "Q15AvhwjxXWvorXLOez+bNUlzX9Z0="
       },
       {
         "name": "busybox",
-        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r40.apk",
-        "version": "1.37.0-r40",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r48.apk",
+        "version": "1.37.0-r48",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6285",
-          "checksum": "sha1-gMvK6tCS0Pw0RLXpjAtSyPSNocc="
+          "range": "bytes=0-6390",
+          "checksum": "sha1-kaHpN1iTRpArTRK84g3Q+cyM478="
         },
         "data": {
-          "range": "bytes=6286-432192",
-          "checksum": "sha256-FKVvv946EX6oH5zOsTaS3AtcrXSIzjih3mYM8ajyi4g="
+          "range": "bytes=6391-425623",
+          "checksum": "sha256-VZWQA8qLD6hYCv84k6pVRJFBBk7f0vUr0fbiIArPwbY="
         },
-        "checksum": "Q1gMvK6tCS0Pw0RLXpjAtSyPSNocc="
+        "checksum": "Q1kaHpN1iTRpArTRK84g3Q+cyM478="
       },
       {
         "name": "wolfi-base",


### PR DESCRIPTION
Tests stopped working as alpine has upgraded to a newer busybox.

Regenerate locks with `./scripts/update_locks.sh`.
