### PR TITLE
bcr: add docs

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,6 +1,0 @@
-# See https://github.com/bazel-contrib/publish-to-bcr#a-note-on-release-automation
-# for guidance about whether to uncomment this section:
-#
-# fixedReleaser:
-#   login: my_github_handle
-#   email: me@my.org

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,6 @@
 {
   "integrity": "**leave this alone**",
   "strip_prefix": "{REPO}-{VERSION}",
+  "docs_url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_apko-{TAG}.docs.tar.gz",
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_apko-{TAG}.tar.gz"
 }

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -11,39 +11,10 @@ ARCHIVE="rules_apko-$TAG.tar.gz"
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
-cat << EOF
-
-## Initial setup (when using with Bazel < 7.1)
-
-rules_apko requires a one-time setup to configure bazel to be able to make partial fetches.
-
-Follow https://github.com/chainguard-dev/rules_apko/blob/main/docs/initial-setup.md for the setup.
-
-EOF
-
-cat << EOF
-## Using Bzlmod
-
-1. Enable with \`common --enable_bzlmod\` in \`.bazelrc\`.
-2. Add to your \`MODULE.bazel\` file:
-
-\`\`\`starlark
-bazel_dep(name = "rules_apko", version = "${TAG:1}")
-\`\`\`
-
-## Using WORKSPACE
-
-Paste this snippet into your `WORKSPACE.bazel` file:
-
-\`\`\`starlark
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "rules_apko",
-    sha256 = "${SHA}",
-    strip_prefix = "${PREFIX}",
-    url = "https://github.com/chainguard-dev/rules_apko/releases/download/${TAG}/${ARCHIVE}",
-)
-EOF
-
-awk 'f;/--SNIP--/{f=1}' e2e/smoke/WORKSPACE.bazel
-echo "\`\`\`" 
+# Add generated API docs to the release, see https://github.com/bazelbuild/bazel-central-registry/issues/5593
+docs="$(mktemp -d)"; targets="$(mktemp)"
+bazel --output_base="$docs" query --output=label --output_file="$targets" 'kind("starlark_doc_extract rule", //...)'
+bazel --output_base="$docs" build --target_pattern_file="$targets" --remote_download_regex='.*doc_extract\.binaryproto'
+tar --create --auto-compress \
+    --directory "$(bazel --output_base="$docs" info bazel-bin)" \
+    --file "$GITHUB_WORKSPACE/${ARCHIVE%.tar.gz}.docs.tar.gz" .

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,11 +2,9 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Set by GH actions, see
-# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-TAG=${GITHUB_REF_NAME}
+TAG=$1
 # The prefix is chosen to match what GitHub generates for source archives
-PREFIX="rules_apko-${TAG:1}"
+PREFIX="rules_apko-$TAG"
 ARCHIVE="rules_apko-$TAG.tar.gz"
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')


### PR DESCRIPTION
- Drop no-op bcr/config.yml.
- Add docs to the template.json
- Drop obsolete / out-of-date release boilerplate
- Add docs in release_prep.sh

Based on recommendations from:
- https://github.com/chainguard-dev/rules_apko/pull/176

note this will remove repetitive boilerplate around obsolete workspace setup in every release notes.