### PR TITLE
github: correct steps output name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       attestations: write
     runs-on: ubuntu-latest
     outputs:
-      tag_name: ${{ steps.check.outputs.existing_tag || steps.create_tag.outputs.new_tag }}
+      tag_name: ${{ steps.check.outputs.existing_tag || steps.create_tag.outputs.git_tag }}
     steps:
       - uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:


### PR DESCRIPTION
The tag action actually has a different output name:
- https://github.com/chainguard-dev/actions/blob/8fa93a69e091d35d496b4af0a32d2e79c8d1ce00/git-tag/action.yml#L47

The git-tag action output is git_tag.

I really really want github workflow validation of template variables.