### PR TITLE
bcr: use immutable source code archive

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_apko-{TAG}.tar.gz"
 }


### PR DESCRIPTION
Go back to immutable source code archive URL. This satisfies bcr checks.

TODO: at release time apply the version number patch, such that no
patching of the tarball is needed on every client.
