### PR TITLE
fix: replace ctx.actions.symlink with cp for Bazel 9 linux-sandbox

### DIFF
--- a/apko/private/apko_config.bzl
+++ b/apko/private/apko_config.bzl
@@ -64,6 +64,32 @@ apko_config = rule(
     },
 )
 
+def copy_to_workdir(ctx, src, dst):
+    """Copy a file or directory to a declared output, sandbox-safe.
+
+    Uses cp instead of ctx.actions.symlink because Bazel 9 sandbox changes
+    cause symlink outputs to dangle when used as inputs to subsequent
+    sandboxed actions.
+
+    See:
+      https://github.com/bazelbuild/bazel/issues/28953
+      https://github.com/bazelbuild/bazel/issues/27068
+
+    Args:
+        ctx: rule context
+        src: source File
+        dst: declared output File or directory
+    """
+    cmd = 'cp -rfL "$1/." "$2/"' if src.is_directory else 'cp -f "$1" "$2"'
+    ctx.actions.run_shell(
+        inputs = [src],
+        outputs = [dst],
+        command = cmd,
+        arguments = [src.path, dst.path],
+        mnemonic = "CopyFile",
+        progress_message = "Copying %s" % src.short_path,
+    )
+
 def prepare_apko_config_in_workdir(workdir, ctx):
     """Helper function to prepare inputs of apko config files for build rules.
 
@@ -81,16 +107,10 @@ def prepare_apko_config_in_workdir(workdir, ctx):
                 input_entry = ctx.actions.declare_directory(paths.join(workdir, f.short_path))
             else:
                 input_entry = ctx.actions.declare_file(paths.join(workdir, f.short_path))
-            ctx.actions.symlink(
-                target_file = f,
-                output = input_entry,
-            )
+            copy_to_workdir(ctx, f, input_entry)
             inputs.append(input_entry)
     else:
-        config_symlink = ctx.actions.declare_file(paths.join(workdir, ctx.file.config.short_path))
-        ctx.actions.symlink(
-            target_file = ctx.file.config,
-            output = config_symlink,
-        )
-        inputs.append(config_symlink)
+        config_copy = ctx.actions.declare_file(paths.join(workdir, ctx.file.config.short_path))
+        copy_to_workdir(ctx, ctx.file.config, config_copy)
+        inputs.append(config_copy)
     return inputs

--- a/apko/private/apko_image.bzl
+++ b/apko/private/apko_image.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:versions.bzl", "versions")
-load("//apko/private:apko_config.bzl", "prepare_apko_config_in_workdir")
+load("//apko/private:apko_config.bzl", "copy_to_workdir", "prepare_apko_config_in_workdir")
 load("//apko/private:apko_run.bzl", "apko_run")
 
 _ATTRS = {
@@ -22,11 +22,16 @@ def _impl(ctx):
     # - bin_dir/target.short_path for generated targets (example bazel-out/.../path/to/my_config)
     # - target.short_path for source files. (example path/to/source_config)
     #
-    # For each input file we create a symlink as workdir/input.short_path
-    # Since the symlink is a generated target, its path is:
+    # For each input file we create a copy as workdir/input.short_path
+    # Since the copy is a generated target, its path is:
     # bin_dir/workspace_root/package/workdir/input.short_path
     #
     # Then when we move to bin_dir/workspace_root/package the relative path become target.short_path for all kinds of input files.
+    #
+    # NOTE: We use file copies instead of ctx.actions.symlink because Bazel 9
+    # sandbox changes cause symlink outputs to become dangling when used as
+    # inputs to subsequent sandboxed actions.
+    # See https://github.com/bazelbuild/bazel/issues/28953
     workdir = "workdir_{}".format(ctx.label.name)
     cache_name = "cache_{}".format(ctx.label.name)
 
@@ -71,12 +76,9 @@ def _impl(ctx):
 
     supports_lockfile = versions.is_at_least("0.13.0", apko_info.version)
     if supports_lockfile:
-        lockfile_symlink = ctx.actions.declare_file(paths.join(workdir, lockfile.short_path))
-        ctx.actions.symlink(
-            target_file = lockfile,
-            output = lockfile_symlink,
-        )
-        inputs.append(lockfile_symlink)
+        lockfile_copy = ctx.actions.declare_file(paths.join(workdir, lockfile.short_path))
+        copy_to_workdir(ctx, lockfile, lockfile_copy)
+        inputs.append(lockfile_copy)
         args.add("--lockfile={}".format(lockfile.short_path))
 
     args.add("--cache-dir={}".format(cache_name))
@@ -90,17 +92,11 @@ def _impl(ctx):
         content_owner = content.owner.workspace_name
         content_cache_entry_key = content.path[content.path.find(content_owner) + len(content_owner) + 1:]
         content_entry = ctx.actions.declare_file(paths.join(workdir, cache_name, content_cache_entry_key))
-        ctx.actions.symlink(
-            target_file = content,
-            output = content_entry,
-        )
+        copy_to_workdir(ctx, content, content_entry)
         inputs.append(content_entry)
 
     apko_binary = ctx.actions.declare_file(paths.join(workdir, apko_info.binary.short_path))
-    ctx.actions.symlink(
-        target_file = apko_info.binary,
-        output = apko_binary,
-    )
+    copy_to_workdir(ctx, apko_info.binary, apko_binary)
     inputs.append(apko_binary)
 
     ctx.actions.run_shell(

--- a/apko/private/apko_show_config.bzl
+++ b/apko/private/apko_show_config.bzl
@@ -1,7 +1,7 @@
 "A rule for expanding apko config"
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//apko/private:apko_config.bzl", "prepare_apko_config_in_workdir")
+load("//apko/private:apko_config.bzl", "copy_to_workdir", "prepare_apko_config_in_workdir")
 
 def _impl(ctx):
     output = ctx.actions.declare_file(ctx.attr.name)
@@ -12,11 +12,16 @@ def _impl(ctx):
     # - bin_dir/target.short_path for generated targets (example bazel-out/.../path/to/my_config)
     # - target.short_path for source files. (example path/to/source_config)
     #
-    # For each input file we create a symlink as workdir/input.short_path
-    # Since the symlink is a generated target, its path is:
+    # For each input file we create a copy as workdir/input.short_path
+    # Since the copy is a generated target, its path is:
     # bin_dir/workspace_root/package/workdir/input.short_path
     #
     # Then when we move to bin_dir/workspace_root/package the relative path become target.short_path for all kinds of input files.
+    #
+    # NOTE: We use file copies instead of ctx.actions.symlink because Bazel 9
+    # sandbox changes cause symlink outputs to become dangling when used as
+    # inputs to subsequent sandboxed actions.
+    # See https://github.com/bazelbuild/bazel/issues/28953
     workdir = "workdir_{}".format(ctx.label.name)
 
     args = ctx.actions.args()
@@ -31,10 +36,7 @@ def _impl(ctx):
     args.add("--offline")
 
     apko_binary = ctx.actions.declare_file(paths.join(workdir, apko_info.binary.short_path))
-    ctx.actions.symlink(
-        target_file = apko_info.binary,
-        output = apko_binary,
-    )
+    copy_to_workdir(ctx, apko_info.binary, apko_binary)
     inputs.append(apko_binary)
 
     ctx.actions.run_shell(


### PR DESCRIPTION
ctx.actions.symlink outputs dangle when used as inputs to sandboxed actions under Bazel 9 with linux-sandbox. The symlink points into the previous sandbox directory which no longer exists.

Reproduce with Bazel 9 + linux-sandbox:

    git checkout HEAD~1   # upstream v1.5.40
    cd e2e/smoke && bazel build :lock   # fails

    git checkout -        # this fix
    cd e2e/smoke && bazel build :lock   # works

Not reproducible with processwrapper-sandbox.

Upstream bugs:
  https://github.com/bazelbuild/bazel/issues/28953
  https://github.com/bazelbuild/bazel/issues/27068

Replace all ctx.actions.symlink calls with cp via copy_to_workdir.