### PR TITLE
fix: stage apko cache as a tree artifact (follow-up to #294)

### DIFF
--- a/apko/private/apko_config.bzl
+++ b/apko/private/apko_config.bzl
@@ -65,11 +65,16 @@ apko_config = rule(
 )
 
 def copy_to_workdir(ctx, src, dst):
-    """Copy a file or directory to a declared output, sandbox-safe.
+    """Copy a file, directory, or list of files to a declared output.
 
     Uses cp instead of ctx.actions.symlink because Bazel 9 sandbox changes
     cause symlink outputs to dangle when used as inputs to subsequent
     sandboxed actions.
+
+    When src is a list, dst must be a declared directory (tree artifact);
+    each source is staged at its workspace-relative path inside dst. This
+    is useful when individual destination paths cannot be declared as
+    per-file outputs (see callers).
 
     See:
       https://github.com/bazelbuild/bazel/issues/28953
@@ -77,17 +82,37 @@ def copy_to_workdir(ctx, src, dst):
 
     Args:
         ctx: rule context
-        src: source File
+        src: source File or list of Files
         dst: declared output File or directory
     """
-    cmd = 'cp -rfL "$1/." "$2/"' if src.is_directory else 'cp -f "$1" "$2"'
+
+    # When f is a directory, append "/." so its contents land directly in
+    # target instead of nesting at target/<basename> (Bazel pre-creates
+    # declared output directories, so plain cp -r src tgt would nest).
+    copy_file_cmd = lambda f, target: 'mkdir -p "{dir}" && cp -rfL "{src}" "{tgt}"'.format(
+        dir = paths.dirname(target),
+        src = (f.path + "/.") if f.is_directory else f.path,
+        tgt = target,
+    )
+
+    # f.short_path for an external file is "../<repo>/<rel>"; strip the
+    # first two segments to recover <rel> for placement in the tree artifact.
+    resolve_target_path = lambda f: paths.join(dst.path, f.short_path.split("/", 2)[-1])
+
+    cmds = ["set -e"]
+    if type(src) == "list":
+        inputs = src
+        cmds += [copy_file_cmd(f, resolve_target_path(f)) for f in src]
+    else:
+        inputs = [src]
+        cmds.append(copy_file_cmd(src, dst.path))
+
     ctx.actions.run_shell(
-        inputs = [src],
+        inputs = inputs,
         outputs = [dst],
-        command = cmd,
-        arguments = [src.path, dst.path],
-        mnemonic = "CopyFile",
-        progress_message = "Copying %s" % src.short_path,
+        command = "\n".join(cmds),
+        mnemonic = "CopyToWorkdir",
+        progress_message = "Staging %s" % dst.short_path,
     )
 
 def prepare_apko_config_in_workdir(workdir, ctx):

--- a/apko/private/apko_image.bzl
+++ b/apko/private/apko_image.bzl
@@ -88,12 +88,15 @@ def _impl(ctx):
         args.add("--arch")
         args.add(ctx.attr.architecture)
 
-    for content in depset(transitive = deps).to_list():
-        content_owner = content.owner.workspace_name
-        content_cache_entry_key = content.path[content.path.find(content_owner) + len(content_owner) + 1:]
-        content_entry = ctx.actions.declare_file(paths.join(workdir, cache_name, content_cache_entry_key))
-        copy_to_workdir(ctx, content, content_entry)
-        inputs.append(content_entry)
+    # Some apko cache entries (notably keyrings) end up at paths whose
+    # filename matches the enclosing directory name, e.g.
+    # ".../wolfi-signing.rsa.pub/wolfi-signing.rsa.pub". Some Bazel
+    # executors reject such paths when declared as individual action
+    # outputs, so we represent the cache as a single tree artifact and
+    # populate it in one action instead.
+    cache_dir = ctx.actions.declare_directory(paths.join(workdir, cache_name))
+    copy_to_workdir(ctx, depset(transitive = deps).to_list(), cache_dir)
+    inputs.append(cache_dir)
 
     apko_binary = ctx.actions.declare_file(paths.join(workdir, apko_info.binary.short_path))
     copy_to_workdir(ctx, apko_info.binary, apko_binary)


### PR DESCRIPTION
After some more testing we noticed that the per-file cp staging introduced in #294 - which replaced ctx.actions.symlink to fix Bazel 9 sandbox issues - regresses on remote execution.

apko's cache is URL-keyed, so when a cached resource's URL ends in its own filename - typical for keyrings, e.g.

    https://packages.wolfi.dev/os/wolfi-signing.rsa.pub

the cache key equals the filename and the entry lands at:

    .../wolfi-signing.rsa.pub/wolfi-signing.rsa.pub

Some remote-execution backends reject declared output paths whose basename equals their parent directory name as REv2 validation failures, so cache staging fails on RBE even though the cp command itself succeeds.

Declare the whole cache as a single tree artifact (via ctx.actions.declare_directory) and populate it in one ctx.actions.run_shell. apko sees the identical files at the identical relative paths, but the problematic paths are now contents of the tree artifact rather than individually declared outputs, so per-output validation no longer sees them.

copy_to_workdir grows a list-of-Files branch for this; the lockfile, config, and apko binary continue through the existing single-file and directory paths unchanged.