### PR TITLE
fix: skip signature segment download for unsigned apks

### DIFF
--- a/apko/private/apk.bzl
+++ b/apko/private/apk.bzl
@@ -92,19 +92,26 @@ def _apk_import_impl(rctx):
     control_sha256 = util.normalize_sri(rctx, rctx.attr.control_checksum)
     data_sha256 = util.normalize_sri(rctx, rctx.attr.data_checksum)
 
-    sig_output = "{}/{}.sig.tar.gz".format(output, control_sha256)
     control_output = "{}/{}.ctl.tar.gz".format(output, control_sha256)
     data_output = "{}/{}.dat.tar.gz".format(output, data_sha256)
     apk_output = "{}/{}/{}-{}.apk".format(repo_escaped, rctx.attr.architecture, rctx.attr.package_name, rctx.attr.version)
 
-    _download(
-        rctx,
-        url = rctx.attr.url,
-        rng = rctx.attr.signature_range,
-        output = sig_output,
-        # TODO: signatures does not have stable checksums. find a way to fail gracefully.
-        # integrity = rctx.attr.signature_checksum,
-    )
+    # Some apks (notably most wolfi packages) ship without an in-apk
+    # signature segment; the lockfile encodes that as an empty range. Issuing
+    # a Range request with an empty value would cause the origin to ignore
+    # the header and return the full file as the "signature", which then
+    # gets concatenated with control+data to produce a doubled apk.
+    sig_output = None
+    if rctx.attr.signature_range:
+        sig_output = "{}/{}.sig.tar.gz".format(output, control_sha256)
+        _download(
+            rctx,
+            url = rctx.attr.url,
+            rng = rctx.attr.signature_range,
+            output = sig_output,
+            # TODO: signatures does not have stable checksums. find a way to fail gracefully.
+            # integrity = rctx.attr.signature_checksum,
+        )
     _download(
         rctx,
         url = rctx.attr.url,

--- a/apko/private/util.bzl
+++ b/apko/private/util.bzl
@@ -102,21 +102,26 @@ def _normalize_sri(rctx, checksum):
     return r.stdout
 
 # TODO: this shouldn't be necessary in the first place. change apko so that it except to find the original apk in the cache
-def _concatenate_gzip_segments(rctx, output, signature, control, data):
+def _concatenate_gzip_segments(rctx, output, control, data, signature = None):
     """concatenates gzip segments into one gzip file in signature, control, data order
 
     Args:
         rctx: repository_ctx
         output: final output path
-        signature: path to the signature segment
         control: path to the control segment
         data: path to the data segment
+        signature: path to the signature segment, or None for unsigned apks
     Returns:
         None
     """
     p = rctx.path("gzip_seg.sh")
-    rctx.file(p, """cat $2 $3 $4 > $1""", executable = True)
-    r = rctx.execute([p, output, signature, control, data])
+    rctx.file(p, """out=$1; shift; cat "$@" > "$out" """, executable = True)
+    args = [p, output]
+    if signature:
+        args.append(signature)
+    args.append(control)
+    args.append(data)
+    r = rctx.execute(args)
     if r.return_code != 0:
         fail("""concatenate_gzip_segments failed.\nstderr: {}\nstdout: {}""".format(r.stdout, r.stderr))
 


### PR DESCRIPTION
When the lockfile encodes an apk with no in-apk signature segment (signature.range = ""), apk_import was still issuing an HTTP GET with Range: "". Origins reject the empty Range header and return the full file with 200 OK, which got written as the "signature" segment; cat sig ctl dat > apk then produced full_apk + ctl + dat = exactly two byte-identical copies concatenated.

Every wolfi package is unsigned (signatures live in the keyring, not the apk), so every wolfi apk in apko's local cache was 2× upstream size. apko v1.2.7 only verified the control hash, which lies at the head of the doubled file and parses fine, so this slipped through. apko v1.2.9's new data-hash check is the first version that catches it (issue #305).

Skip the signature download when signature_range is empty, and concatenate only ctl + dat into the unified apk.
