### PR TITLE
Add bazel to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "bazel"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Our bazel deps are very out of date, add dependabot config to bump these things.