### PR TITLE
fix: disable remote execution for apko_image build action

### DIFF
--- a/apko/private/apko_image.bzl
+++ b/apko/private/apko_image.bzl
@@ -109,6 +109,7 @@ def _impl(ctx):
         tools = [apko_info.binary],
         outputs = [output],
         use_default_shell_env = True,
+        execution_requirements = {"no-remote-exec": "1"},
     )
 
     return DefaultInfo(


### PR DESCRIPTION
The run_shell action in apko_image uses use_default_shell_env and absolute local paths, making it incompatible with remote executors. Add execution_requirements = {"no-remote-exec": "1"} to force local execution. 

Fixes #331.