### PR TITLE
fix: make apko image action explicit about toolchains

### DIFF
--- a/apko/private/apko_image.bzl
+++ b/apko/private/apko_image.bzl
@@ -110,6 +110,7 @@ def _impl(ctx):
         outputs = [output],
         use_default_shell_env = True,
         execution_requirements = {"no-remote-exec": "1"},
+        toolchain = None,
     )
 
     return DefaultInfo(


### PR DESCRIPTION
The --incompatible_auto_exec_groups flag requires Starlark actions to declare whether their executable/tools come from an action toolchain. This is not a Bazel default today, but it is exposed through strict preset configurations and is intended to catch rules that rely on implicit action toolchain inference.

apko_image copies the apko binary into its working directory and runs that copy through a shell command. Mark the action with toolchain = None so its action toolchain behavior is explicit without changing its inputs or execution model.