### PR TITLE
ci: add test-roundup summary gate for the test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,3 +112,25 @@ jobs:
         working-directory: ${{ matrix.folder }}
         if: ${{ matrix.bazelversion <= '8.' && matrix.folder == '.' }}
         run: bazel query 'tests(//...) except docs/...' | xargs bazel test
+
+  # Single summary gate that aggregates the dynamic test matrix. Branch
+  # protection only needs to require this one context, so the Bazel version
+  # matrix above can change without an infra change to the required checks.
+  test-roundup:
+    runs-on: ubuntu-latest
+    needs:
+      - matrix-prep-bazelversion
+      - matrix-prep-os
+      - test
+    if: always()
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Verify needs succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON"
+          jq -e 'all(.[]; .result | IN("success","skipped"))' <<< "$NEEDS_JSON"


### PR DESCRIPTION
## What

Adds a single `test-roundup` job that fans in over the dynamic `test` matrix (and the `matrix-prep-*` jobs). It passes only when every dependency reports `success` or `skipped`.

## Why

Today branch protection has to enumerate each matrix leg by name — e.g. `test (ubuntu-latest, 8.6.0, .)`, `test (ubuntu-latest, 9.1.0, e2e/smoke)`, … — in the [infra repo](https://github.com/chainguard-dev/infra) required-status-checks config. Every time the Bazel version matrix in this workflow changes, the required checks drift out of sync and need a matching infra PR (renamed legs otherwise sit as `expected`/pending forever and block merge).

With this gate, infra can require just the single `test-roundup` context, and the matrix here can change freely without any infra change.

## How it's safe

Two load-bearing details, mirroring the roundup pattern already used in `images-private`:

- **`if: always()`** — the gate runs even when a matrix leg fails. Without it the gate would be *skipped*, and a skipped required check counts as passing, letting broken PRs merge.
- **`jq -e 'all(.[]; .result | IN("success","skipped"))'`** — explicitly fails the gate unless every dependency succeeded or was skipped. The `matrix-prep-*` jobs are included in `needs` so a prep failure (which would *skip* `test`) is still caught.

Follow-up infra change will switch the `rules_apko` required contexts to `test-roundup` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)