### PR TITLE
apk_keyring: prefer embedded content over URL fetch

### DIFF
--- a/apko/extensions.bzl
+++ b/apko/extensions.bzl
@@ -46,6 +46,7 @@ def _apko_extension_impl(module_ctx):
                     apk_keyring(
                         name = util.sanitize_string("{}_{}".format(lock.name, keyring["name"])),
                         url = keyring["url"],
+                        content = keyring.get("content", ""),
                     )
 
             for repository in lock_file["contents"]["repositories"]:

--- a/apko/private/apk.bzl
+++ b/apko/private/apk.bzl
@@ -184,13 +184,19 @@ def _cachePathFromURL(url):
 
 def _apk_keyring_impl(rctx):
     public_key = _cachePathFromURL(rctx.attr.url)
-    rctx.download(url = [rctx.attr.url], output = public_key, auth = _auth(rctx, rctx.attr.url))
+    if rctx.attr.content:
+        rctx.file(public_key, rctx.attr.content)
+    else:
+        rctx.download(url = [rctx.attr.url], output = public_key, auth = _auth(rctx, rctx.attr.url))
     rctx.file("BUILD.bazel", APK_KEYRING_TMPL.format(public_key = public_key))
 
 apk_keyring = repository_rule(
     implementation = _apk_keyring_impl,
     attrs = {
         "url": attr.string(mandatory = True),
+        "content": attr.string(
+            doc = "Raw keyring bytes (typically a PEM-encoded public key). When set, the URL is not fetched.",
+        ),
     },
 )
 

--- a/apko/translate_lock.bzl
+++ b/apko/translate_lock.bzl
@@ -59,7 +59,8 @@ APK_REPOSITORY_TMPL = """\
 APK_KEYRING_TMPL = """\
     apk_keyring(
         name = "{name}",
-        url = "{url}"
+        url = "{url}",
+        content = {content},
     )
 """
 
@@ -84,6 +85,7 @@ def _translate_apko_lock_impl(rctx):
             defs.append(APK_KEYRING_TMPL.format(
                 name = name,
                 url = keyring["url"],
+                content = repr(keyring.get("content", "")),
             ))
 
     for package in lock_file["contents"]["packages"]:

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -23,3 +23,9 @@ apko.translate_lock(
     lock = "//multifile_config:apko.generated.lock.json",
 )
 use_repo(apko, "example_multifile_lock")
+
+apko.translate_lock(
+    name = "keyring_content_lock",
+    lock = "//keyring_content:apko.lock.json",
+)
+use_repo(apko, "keyring_content_lock")

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -41,3 +41,12 @@ translate_apko_lock(
 load("@example_multifile_lock//:repositories.bzl", multifile_lock_repositories = "apko_repositories")
 
 multifile_lock_repositories()
+
+translate_apko_lock(
+    name = "keyring_content_lock",
+    lock = "@//keyring_content:apko.lock.json",
+)
+
+load("@keyring_content_lock//:repositories.bzl", keyring_content_lock_repositories = "apko_repositories")
+
+keyring_content_lock_repositories()

--- a/e2e/smoke/keyring_content/BUILD
+++ b/e2e/smoke/keyring_content/BUILD
@@ -1,0 +1,13 @@
+"""Test that keyring bytes embedded in the lockfile are used without hitting the URL.
+
+The lockfile in this package points at an unreachable host but embeds the keyring
+content inline. If the URL is ever fetched, the build fails; if the content path
+is used, the build succeeds.
+"""
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+build_test(
+    name = "keyring_content_test",
+    targets = ["@keyring_content_lock//:contents"],
+)

--- a/e2e/smoke/keyring_content/apko.lock.json
+++ b/e2e/smoke/keyring_content/apko.lock.json
@@ -1,0 +1,23 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "./keyring_content/apko.yaml",
+    "checksum": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "keyring-content-test.invalid/keys/test.rsa.pub",
+        "url": "https://keyring-content-test.invalid/keys/test.rsa.pub",
+        "content": "-----BEGIN PUBLIC KEY-----\nEmbedded keyring bytes for rules_apko e2e test. If this file exists in\nthe keyring repo without a network fetch, the content-consumption path\nworks; the URL host above is intentionally unreachable so a fallback\nfetch would fail the test.\n-----END PUBLIC KEY-----\n"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [],
+    "packages": [],
+    "archs": [
+      "x86_64"
+    ]
+  }
+}


### PR DESCRIPTION
If the lockfile keyring entry carries a `content` field (added in chainguard-dev/apko#2322), write those bytes to disk instead of fetching the URL. Old lockfiles without `content` fall through to the existing URL-fetch path, so this is a no-op for them.

Fixes builds against locks whose upstream key URL 404s after a key rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)