### PR TITLE
Mark repo_rules as `reproducible`

### DIFF
--- a/apko/private/apk.bzl
+++ b/apko/private/apk.bzl
@@ -102,6 +102,23 @@ def _apk_import_impl(rctx):
     )
     rctx.file("BUILD.bazel", APK_IMPORT_TMPL)
 
+    # The control and data segments - the whole apk payload - are integrity
+    # pinned from the lockfile, and every path written here is derived from the
+    # attrs, so the contents are a pure function of the recorded inputs.
+    #
+    # Two things are deliberately not treated as blockers:
+    #  - The signature segment is fetched unpinned (see the TODO above). It is a
+    #    fixed byte range of an immutable published apk, and apko verifies it
+    #    against the keyring at build time, so a cache hit cannot smuggle in a
+    #    signature that a fresh fetch would have rejected.
+    #  - `HTTP_AUTH` is read via `rctx.os.environ`, which is not a recorded
+    #    input. It only decides whether a request is authorised, never what the
+    #    verified bytes are, so it cannot fork the contents for a given key.
+    #
+    # A rules_apko release can invalidate stale cache entries by bumping
+    # `RULES_APKO_CACHE_KEY`, which flows into the `rules_apko_cache_key` attr.
+    return util.repo_metadata(rctx, reproducible = True)
+
 apk_import = repository_rule(
     implementation = _apk_import_impl,
     attrs = {
@@ -137,6 +154,15 @@ def _apk_repository_impl(rctx):
         output = "{}/{}/APKINDEX/latest.tar.gz".format(repo_escaped, rctx.attr.architecture),
     )
     rctx.file("BUILD.bazel", APK_REPOSITORY_TMPL)
+
+    # Deliberately not marked reproducible.
+    #
+    # `url` points at the repository's live `APKINDEX.tar.gz`, which is rewritten
+    # every time a package is published, and the download is not checksum pinned.
+    # The contents are therefore a function of fetch time, not of the attrs, and
+    # sharing them across machines could pair a lockfile with an index that
+    # predates it.
+    return util.repo_metadata(rctx, reproducible = False)
 
 apk_repository = repository_rule(
     implementation = _apk_repository_impl,
@@ -190,6 +216,16 @@ def _apk_keyring_impl(rctx):
         rctx.download(url = [rctx.attr.url], output = public_key, auth = _auth(rctx, rctx.attr.url))
     rctx.file("BUILD.bazel", APK_KEYRING_TMPL.format(public_key = public_key))
 
+    # With `content` set nothing is fetched at all, so the repo is templated
+    # purely from the attrs. Without it the key is fetched unpinned, but a
+    # signing key URL names one specific key: rotation publishes a new
+    # `*.rsa.pub` filename rather than rewriting an existing one, so the bytes at
+    # a given `url` do not change. `_cachePathFromURL` derives the layout from
+    # `url` alone, never from the host. Should that assumption ever be violated,
+    # a rules_apko release can invalidate cached keyrings by bumping
+    # `RULES_APKO_CACHE_KEY`.
+    return util.repo_metadata(rctx, reproducible = True)
+
 apk_keyring = repository_rule(
     implementation = _apk_keyring_impl,
     attrs = {
@@ -197,6 +233,7 @@ apk_keyring = repository_rule(
         "content": attr.string(
             doc = "Raw keyring bytes (typically a PEM-encoded public key). When set, the URL is not fetched.",
         ),
+        "rules_apko_cache_key": attr.string(default = RULES_APKO_CACHE_KEY),
     },
 )
 

--- a/apko/private/toolchains_repo.bzl
+++ b/apko/private/toolchains_repo.bzl
@@ -17,6 +17,8 @@ This guidance tells us how to avoid that: we put the toolchain targets in the al
 with only the toolchain attribute pointing into the platform-specific repositories.
 """
 
+load(":util.bzl", "util")
+
 # Add more platforms as needed to mirror all the binaries
 # published by the upstream project.
 PLATFORMS = {
@@ -80,6 +82,10 @@ toolchain(
 
     # Base BUILD file for this repository
     repository_ctx.file("BUILD.bazel", build_content)
+
+    # The only output is a BUILD file templated from the attrs and the `PLATFORMS`
+    # constant. Nothing is downloaded and nothing is read from the host.
+    return util.repo_metadata(repository_ctx, reproducible = True)
 
 toolchains_repo = repository_rule(
     _toolchains_repo_impl,

--- a/apko/private/util.bzl
+++ b/apko/private/util.bzl
@@ -84,6 +84,25 @@ def _sanitize_string(string):
 def _parse_lock(content):
     return json.decode(content)
 
+def _repo_metadata(rctx, reproducible):
+    """Reports this repo's reproducibility to the repo contents cache.
+
+    `repository_ctx.repo_metadata` (and the repo contents cache it feeds) is
+    only available since Bazel 8.3.0, which is above the minimum Bazel version
+    supported by rules_apko. On older Bazels there is no cache to inform, so
+    fall back to the implicit None return those versions have always accepted.
+
+    Args:
+        rctx: repository_ctx
+        reproducible: True if refetching this repo with the same recorded
+            inputs is guaranteed to produce the same contents
+    Returns:
+        a value to return from the repository rule's implementation function
+    """
+    if not hasattr(rctx, "repo_metadata"):
+        return None
+    return rctx.repo_metadata(reproducible = reproducible)
+
 def _normalize_sri(rctx, checksum):
     """Converts SRI string to a plain checksum hex.
 
@@ -129,6 +148,7 @@ util = struct(
     concatenate_gzip_segments = _concatenate_gzip_segments,
     normalize_sri = _normalize_sri,
     parse_lock = _parse_lock,
+    repo_metadata = _repo_metadata,
     sanitize_string = _sanitize_string,
     repo_url = _repo_url,
     url_escape = _url_escape,

--- a/apko/repositories.bzl
+++ b/apko/repositories.bzl
@@ -7,6 +7,7 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//apko/private:toolchains_repo.bzl", "PLATFORMS", "toolchains_repo")
+load("//apko/private:util.bzl", "util")
 load("//apko/private:versions.bzl", "APKO_VERSIONS")
 
 LATEST_APKO_VERSION = APKO_VERSIONS.keys()[0]
@@ -71,6 +72,12 @@ apko_toolchain(
 )
 """.format(version = repository_ctx.attr.apko_version),
     )
+
+    # The archive is integrity pinned via the mandatory `sha256` attr and the
+    # generated BUILD file is templated from the attrs. The target platform comes
+    # from the `url` / `platform` attrs, so it is part of the cache key rather
+    # than being read off the host.
+    return util.repo_metadata(repository_ctx, reproducible = True)
 
 apko_repositories = repository_rule(
     _apko_repo_impl,

--- a/apko/translate_lock.bzl
+++ b/apko/translate_lock.bzl
@@ -65,11 +65,21 @@ APK_KEYRING_TMPL = """\
 """
 
 def _translate_apko_lock_impl(rctx):
-    lock_file = util.parse_lock(rctx.read(rctx.attr.lock))
+    lock_content = rctx.read(rctx.attr.lock)
+    lock_file = util.parse_lock(lock_content)
 
     # We copy the lockfile (.lock.json) to avoid visibility problems when we reference it from another module.
     lock_file_local = "lockfile_copy"
-    rctx.symlink(rctx.attr.lock, lock_file_local)
+    if hasattr(rctx, "repo_metadata"):
+        # The copy has to be a real file rather than a symlink: an external repo
+        # holding a symlink that escapes its own root is never stored in the
+        # repo contents cache.
+        rctx.file(lock_file_local, lock_content, executable = False)
+    else:
+        # No repo contents cache on this Bazel (see util.repo_metadata), so keep
+        # the symlink: unlike `rctx.file` on these versions, it is guaranteed to
+        # preserve the lockfile bytes exactly.
+        rctx.symlink(rctx.attr.lock, lock_file_local)
 
     apks = []
     indexes = []
@@ -125,6 +135,11 @@ def _translate_apko_lock_impl(rctx):
         "BUILD.bazel",
         BUILD_TMPL.format(apks = apks, keyrings = keyrings, indexes = indexes, lockfile = lock_file_local),
     )
+
+    # Everything written here is derived from the `lock` file and the
+    # `target_name` attr, both recorded inputs, and nothing is downloaded or read
+    # from the host.
+    return util.repo_metadata(rctx, reproducible = True)
 
 translate_apko_lock = repository_rule(
     implementation = _translate_apko_lock_impl,


### PR DESCRIPTION
Bazel only stores a repo in the repo contents cache (`--repo_contents_cache`) when the repository rule reports itself as
reproducible, i.e. same recorded inputs => same repo contents. None of the `rules_apko` repository rules said anything, so every apk, keyring and toolchain repo was re-fetched from scratch in each output base between builds.

Mark the rules whose contents are a pure function of their attrs:

  * `apk_import` - the apk payload is integrity pinned by the lockfile.
  * `apk_keyring` - written from `content`, or fetched from a URL that names one immutable signing key.
  * `translate_apko_lock` - templated from the lockfile.
  * `apko_repositories` - the apko binary is integrity pinned.
  * `toolchains_repo` - templated from the attrs.

`translate_apko_lock` also has to copy the lockfile instead of symlinking it, because a repo containing a symlink out of its own root is never cached.

`apk_repository` is the one exception: it fetches a live, unpinned `APKINDEX.tar.gz`, so its contents depend on when it ran rather than on its attrs. It returns `reproducible = False` explicitly so the reasoning does not have to be rediscovered.

The `apko` module extension is already marked reproducible upstream.

On Bazel versions before 8.3.0 (no repo_metadata), the rules behave exactly as before — nothing is cached and the lockfile stays a symlink.