### PR TITLE
ci: persist the Bazel disk cache between runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,16 @@ jobs:
       - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # v0.19.0
         with:
           repository-cache: true
+          # Persist action outputs between runs. Only the Bazel 9 x '.' cell
+          # runs the docs tests, and stardoc drags in protoc, the protobuf
+          # Java runtime, and the stardoc renderer - around 900 actions
+          # recompiled from scratch on every run without this. Keyed by Bazel
+          # version because different versions produce different outputs.
+          disk-cache: ${{ matrix.bazelversion }}
+          # Pull requests restore the cache but never write it, so a PR cannot
+          # evict main's entry and GitHub's per-branch cache isolation does not
+          # leave PRs writing caches nothing else can read.
+          cache-save: ${{ github.event_name != 'pull_request' }}
           bazelrc: |
             common --announce_rc --color=yes --enable_bzlmod
             test --test_output=errors


### PR DESCRIPTION
## Summary

The `9.1.0 × .` matrix cell takes far longer than every other cell because it is the only one that runs the docs tests. `stardoc_with_diff_test` pulls in `protoc`, the protobuf Java runtime, and the stardoc renderer — roughly 900 actions, recompiled from scratch on every run, because nothing persists action outputs between runs.

This enables `setup-bazel`'s disk cache:

```yaml
disk-cache: ${{ matrix.bazelversion }}
cache-save: ${{ github.event_name != 'pull_request' }}
```

Keyed by Bazel version so the four versions in the matrix don't evict each other's outputs. `cache-save` on non-PR runs only is the action's own recommended pattern — `main` populates the cache and PRs restore from it without writing, so no PR can evict `main`'s entry, and PRs don't write caches that GitHub's per-branch isolation would make unreadable to anything else.

## Note: `.github/workflows/ci.bazelrc` is dead

It already sets `build --disk_cache=~/.cache/bazel`, and its comment says *"This directory is configured in GitHub actions to be persisted between runs."* But nothing references the file — `grep -rn ci.bazelrc` finds only a pointer comment in `//.bazelrc`, and the file hasn't been touched since the initial commit. `ci.yaml` passes bazelrc content inline through `setup-bazel` instead, so that setting has not been taking effect.

I left the file alone rather than deleting it as a drive-by. Happy to remove it in this PR or a follow-up, whichever you prefer. Note it also carries `test --test_env=XDG_CACHE_HOME`, which is likewise not currently applied.

## A larger option, if you want it

`registry.bazel.build` renders Starlark docs for modules that publish them, and the extraction rule (`starlark_doc_extract`) is built into Bazel — it needs no stardoc dependency, so it costs none of the protobuf/Java compilation above. Publishing `{REPO}-{TAG}.docs.tar.gz` from the release workflow and adding a `docs_url` to `.bcr/source.template.json` would render the API reference on BCR, generated from source at publish time.

That would make `stardoc_with_diff_test` unnecessary by construction — there'd be no checked-in artifact to drift — and remove the stardoc build from CI entirely rather than just caching it. It also means dropping `docs/*.md`, which the README currently links, so it's a real trade and a separate decision. This PR is just the cheap fix.

## Test plan

`actionlint` clean (the pre-existing SC2086 findings in `ci.yaml` are unchanged). The effect is only visible across runs: the first `main` run after merge populates the cache, subsequent runs restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
