### PR TITLE
ci: float the Bazel matrix per LTS series and add a rolling canary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,10 +47,23 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Floating identifiers, resolved by bazelisk: N.x is the latest release
+      # of the LTS series started by N.0.0, and rolling is the latest rolling
+      # release. These track new releases without anyone bumping them by hand.
+      # .bcr/presubmit.yml already uses the same form.
+      - id: bazel_rolling
+        run: echo "bazelversion=rolling" >> $GITHUB_OUTPUT
+      - id: bazel_9x
+        run: echo "bazelversion=9.x" >> $GITHUB_OUTPUT
+      - id: bazel_8x
+        run: echo "bazelversion=8.x" >> $GITHUB_OUTPUT
+      - id: bazel_7x
+        run: echo "bazelversion=7.x" >> $GITHUB_OUTPUT
+      # Pinned: 9.1.0 is what .bazelversion gives contributors locally, and
+      # 8.3.0 and 7.6.1 are the oldest releases of their series the matrix
+      # covers, so the floating entries above cannot silently drop them.
       - id: bazel_91
         run: echo "bazelversion=9.1.0" >> $GITHUB_OUTPUT
-      - id: bazel_86
-        run: echo "bazelversion=8.6.0" >> $GITHUB_OUTPUT
       - id: bazel_83
         run: echo "bazelversion=8.3.0" >> $GITHUB_OUTPUT
       - id: bazel_76
@@ -62,6 +75,11 @@ jobs:
   test:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
+
+    # Only the rolling cell is advisory. A cell with continue-on-error counts
+    # as a success for anything that needs: this job, so every supported
+    # version still gates test-roundup.
+    continue-on-error: ${{ matrix.bazelversion == 'rolling' }}
 
     needs:
       - matrix-prep-bazelversion
@@ -104,13 +122,13 @@ jobs:
 
       - name: Test
         working-directory: ${{ matrix.folder }}
-        if: ${{ matrix.bazelversion >= '9.' || matrix.folder != '.' }}
+        if: ${{ matrix.folder != '.' || matrix.bazelversion == 'rolling' || startsWith(matrix.bazelversion, '9.') }}
         run: bazel test //...
 
       # Stardoc has output changes between versions
       - name: Test no doc 8 and lower
         working-directory: ${{ matrix.folder }}
-        if: ${{ matrix.bazelversion <= '8.' && matrix.folder == '.' }}
+        if: ${{ matrix.folder == '.' && (startsWith(matrix.bazelversion, '8.') || startsWith(matrix.bazelversion, '7.')) }}
         run: bazel query 'tests(//...) except docs/...' | xargs bazel test
 
   # Single summary gate that aggregates the dynamic test matrix. Branch


### PR DESCRIPTION
## Summary

The matrix pins four Bazel versions, and each was the newest of its series when it was added — 7.6.1 in #108, 8.3.0 in #144, 9.1.0 and 8.6.0 in #298. They have since gone stale: CI tests 9.1.0 and 8.6.0 while 9.2.0 and 8.7.0 are released. Every new Bazel release needs someone to notice and send a bump.

Bazelisk resolves floating identifiers, so the series heads can track releases themselves:

> A floating version identifier like `4.x` that returns the latest **release** from the LTS series started by Bazel 4.0.0.

`.bcr/presubmit.yml` already expresses its matrix this way (`bazel: ["7.x", "8.x", "9.x"]`), so this makes the two agree.

Verified with bazelisk locally:

```
9.x      -> bazel 9.2.0
8.x      -> bazel 8.7.0
7.x      -> bazel 7.7.1
rolling  -> bazel 10.0.0-pre.20260811.3
```

## The matrix

| Entry | Why |
|---|---|
| `rolling` | Bazel 10 canary — advisory, see below |
| `9.x` `8.x` `7.x` | latest release of each LTS series, tracked automatically |
| `9.1.0` | what `.bazelversion` gives contributors locally |
| `8.3.0` `7.6.1` | oldest release of their series the matrix covers today |

The pins stay because the floating entries would otherwise silently drop coverage of older releases. Note that none of them was ever a deliberate minimum — there is no `bazel_compatibility` in `MODULE.bazel` — so if you have a stated support floor, these should be set to it and the rest dropped.

## rolling cannot block a merge

```yaml
continue-on-error: ${{ matrix.bazelversion == 'rolling' }}
```

A cell with `continue-on-error` counts as a success for anything that `needs:` the job, so a broken rolling release shows up in the UI without failing `test-roundup`. It applies to that cell alone, so every supported version still gates as before — a real failure in `9.x` fails the roundup exactly as a failure in `9.1.0` does today.

## One incidental fix

The docs-test conditions compared version strings relationally:

```yaml
if: ${{ matrix.bazelversion >= '9.' || matrix.folder != '.' }}
```

That does not extend to `rolling` or `N.x`, and a cell matching neither branch would silently run no tests at all while reporting green. They now match on the series prefix with `startsWith`, which is well defined for every entry.

(If #382 lands first these two conditions disappear entirely, and this hunk should be dropped in the rebase.)

## Test plan

This PR validates itself — the new matrix runs on it. `9.x` and the pinned cells gate; `rolling` is advisory, and whatever it reports here is the first data point on Bazel 10 readiness.

`actionlint` clean (the pre-existing SC2086 findings in `ci.yaml` are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
